### PR TITLE
Fix(liked): Prevent crash on blank favorites page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,28 +10,7 @@ import { AIQuestionGenerator } from "./components/ai-question-generator/ai-quest
 import { Link } from "react-router-dom";
 import { useTheme } from "./hooks/useTheme";
 import { AnimatePresence } from "framer-motion";
-
-function useLocalStorage<T>(key: string, initialValue: T) {
-  const [storedValue, setStoredValue] = useState<T>(() => {
-    try {
-      const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      return initialValue;
-    }
-  });
-
-  const setValue = (value: T) => {
-    try {
-      setStoredValue(value);
-      window.localStorage.setItem(key, JSON.stringify(value));
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  return [storedValue, setValue] as const;
-}
+import { useLocalStorage } from "./hooks/useLocalStorage";
 
 export default function App() {
   const { theme, setTheme } = useTheme();

--- a/src/app/liked/page.tsx
+++ b/src/app/liked/page.tsx
@@ -1,23 +1,11 @@
 import { useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Doc, Id } from "../../../convex/_generated/dataModel";
 import CardShuffleLoader from "../../components/card-shuffle-loader/card-shuffle-loader";
 import { Link } from "react-router-dom";
 import { useTheme } from "../../hooks/useTheme";
-
-function useLocalStorage<T>(key: string, initialValue: T) {
-  const [storedValue, setStoredValue] = useState<T>(() => {
-    try {
-      const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      return initialValue;
-    }
-  });
-
-  return [storedValue] as const;
-}
+import { useLocalStorage } from "../../hooks/useLocalStorage";
 
 export default function LikedQuestionsPage() {
   const { theme, setTheme } = useTheme();

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,39 @@
+import { useState } from "react";
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      const item = window.localStorage.getItem(key);
+      if (!item) {
+        return initialValue;
+      }
+      const value = JSON.parse(item);
+      // If initialValue is an array, ensure the stored value is also an array.
+      // This prevents crashes if the data in localStorage is corrupted.
+      if (Array.isArray(initialValue) && !Array.isArray(value)) {
+        return initialValue;
+      }
+      return value;
+    } catch (error) {
+      console.error(error);
+      return initialValue;
+    }
+  });
+
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return [storedValue, setValue] as const;
+}


### PR DESCRIPTION
The favorites page was blank due to a runtime crash when data in local storage was malformed. The `useQuery` hook would fail when it received invalid arguments, causing the component to fail to render.

This was caused by a `useLocalStorage` hook that was not robust enough to handle unexpected data formats. The hook was also duplicated in `App.tsx` and `src/app/liked/page.tsx`.

This commit addresses the issue by:
1. Creating a single, robust, shared `useLocalStorage` hook in `src/hooks/useLocalStorage.ts`. This new hook validates the data retrieved from local storage and falls back to the initial value if the data is corrupted, preventing the application from crashing.
2. Refactoring both `App.tsx` and `src/app/liked/page.tsx` to use this new shared hook, eliminating duplicated code and ensuring consistent, safe access to local storage across the application.