### PR TITLE
Add auto shuffle advance settings

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -18,6 +18,7 @@ const SettingsPage = () => {
   const [hiddenStyles, setHiddenStyles] = useLocalStorage<string[]>("hiddenStyles", []);
   const [hiddenTones, setHiddenTones] = useLocalStorage<string[]>("hiddenTones", []);
   const [hiddenQuestions, setHiddenQuestions] = useLocalStorage<string[]>("hiddenQuestions", []);
+  const [autoAdvanceShuffle, setAutoAdvanceShuffle] = useLocalStorage<boolean>("autoAdvanceShuffle", false);
 
   const unhideStyle = (styleId: string) => {
     setHiddenStyles(prev => prev.filter(id => id !== styleId));
@@ -52,6 +53,24 @@ const SettingsPage = () => {
         <h1 className="text-3xl font-bold mb-6 dark:text-white text-black">Settings</h1>
 
         <div className="space-y-8">
+          <CollapsibleSection title="Shuffle" count={undefined}>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="dark:text-white text-black font-semibold">Auto-advance Shuffle</p>
+                <p className="text-sm dark:text-white/70 text-black/70">Automatically confirm style and tone after shuffling.</p>
+              </div>
+              <button
+                onClick={() => setAutoAdvanceShuffle(!autoAdvanceShuffle)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${autoAdvanceShuffle ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
+                aria-pressed={autoAdvanceShuffle}
+                aria-label="Toggle auto-advance shuffle"
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${autoAdvanceShuffle ? 'translate-x-6' : 'translate-x-1'}`}
+                />
+              </button>
+            </div>
+          </CollapsibleSection>
           <CollapsibleSection title="Hidden Styles" count={hiddenStyleObjects?.length}>
             {hiddenStyleObjects && hiddenStyleObjects.length > 0 ? (
               <>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -27,6 +27,7 @@ export default function MainPage() {
   const [selectedTone, setSelectedTone] = useState("fun-silly");
   const [randomizedTone, setRandomizedTone] = useState<string | null>(null);
   const [randomizedStyle, setRandomizedStyle] = useState<string | null>(null);
+  const [autoAdvanceShuffle] = useLocalStorage<boolean>("autoAdvanceShuffle", false);
   const toneSelectorRef = useRef<ToneSelectorRef>(null);
   const styleSelectorRef = useRef<StyleSelectorRef>(null);
   const generateAIQuestion = useAction(api.ai.generateAIQuestion);
@@ -153,6 +154,11 @@ export default function MainPage() {
   const handleShuffleStyleAndTone = () => {
     toneSelectorRef.current?.randomizeTone();
     styleSelectorRef.current?.randomizeStyle();
+    if (autoAdvanceShuffle) {
+      setTimeout(() => {
+        handleConfirmRandomizeStyleAndTone();
+      }, 0);
+    }
   }
   const handleCancelRandomizeStyleAndTone = () => {
     toneSelectorRef.current?.cancelRandomizingTone();


### PR DESCRIPTION
Add an 'Auto-advance Shuffle' setting to automatically confirm randomized style and tone after shuffling.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ee9a42e-9bb4-4e15-8601-43af2dda7712">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ee9a42e-9bb4-4e15-8601-43af2dda7712">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

