### PR TITLE
feat: Implement landing page with bypass option

### DIFF
--- a/src/Root.test.tsx
+++ b/src/Root.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Navigate } from 'react-router-dom';
+import Root from './Root';
+import { useLocalStorage } from './hooks/useLocalStorage';
+
+// Mock dependencies
+vi.mock('./hooks/useLocalStorage');
+vi.mock('./pages/LandingPage', () => ({
+  default: () => <div>Landing Page</div>,
+}));
+vi.mock('react-router-dom', async (importOriginal) => {
+    const original = await importOriginal<typeof import('react-router-dom')>();
+    return {
+        ...original,
+        Navigate: vi.fn(({ to }) => <div>Navigating to {to}</div>),
+    };
+});
+
+describe('Root component', () => {
+  it('should render LandingPage when bypassLandingPage is false', () => {
+    // Arrange
+    vi.mocked(useLocalStorage).mockReturnValue([false, vi.fn()]);
+
+    // Act
+    render(
+      <MemoryRouter>
+        <Root />
+      </MemoryRouter>
+    );
+
+    // Assert
+    expect(screen.getByText('Landing Page')).toBeInTheDocument();
+    expect(vi.mocked(Navigate)).not.toHaveBeenCalled();
+  });
+
+  it('should navigate to /app when bypassLandingPage is true', () => {
+    // Arrange
+    vi.mocked(useLocalStorage).mockReturnValue([true, vi.fn()]);
+
+    // Act
+    render(
+      <MemoryRouter>
+        <Root />
+      </MemoryRouter>
+    );
+
+    // Assert
+    expect(screen.queryByText('Landing Page')).not.toBeInTheDocument();
+    // Check the props of the Navigate component
+    const navigateProps = vi.mocked(Navigate).mock.calls[0][0];
+    expect(navigateProps.to).toBe('/app');
+    expect(navigateProps.replace).toBe(true);
+    expect(screen.getByText('Navigating to /app')).toBeInTheDocument();
+  });
+});

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,0 +1,15 @@
+import { useLocalStorage } from "./hooks/useLocalStorage";
+import { Navigate } from "react-router-dom";
+import LandingPage from "./pages/LandingPage";
+
+const Root = () => {
+  const [bypassLandingPage] = useLocalStorage<boolean>("bypassLandingPage", false);
+
+  if (bypassLandingPage) {
+    return <Navigate to="/app" replace />;
+  }
+
+  return <LandingPage />;
+};
+
+export default Root;

--- a/src/app/question/page.test.tsx
+++ b/src/app/question/page.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import QuestionPage from './page';
 import { useQuery } from 'convex/react';
-import { useParams } from 'react-router-dom';
+import { useParams, MemoryRouter } from 'react-router-dom';
 import { Id } from '../../../convex/_generated/dataModel';
 
 // Mock dependencies
@@ -12,6 +12,7 @@ vi.mock('react-router-dom', async () => {
   return {
     ...actual,
     useParams: vi.fn(),
+    useNavigate: () => vi.fn(),
     Link: (props: any) => <a {...props} href={props.to}>{props.children}</a>,
   };
 });
@@ -43,14 +44,14 @@ describe('QuestionPage', () => {
 
   it('renders a loading spinner while fetching the question', () => {
     mockUseQuery.mockReturnValue(undefined);
-    render(<QuestionPage />);
+    render(<MemoryRouter><QuestionPage /></MemoryRouter>);
     expect(screen.queryByText('Question not found')).not.toBeInTheDocument();
     // In a real app, we'd check for the spinner role, but this is sufficient for now.
   });
 
   it('renders "Question not found" when the question is null', () => {
     mockUseQuery.mockReturnValue(null);
-    render(<QuestionPage />);
+    render(<MemoryRouter><QuestionPage /></MemoryRouter>);
     expect(screen.getByText('Question not found')).toBeInTheDocument();
   });
 
@@ -66,7 +67,7 @@ describe('QuestionPage', () => {
       .mockReturnValueOnce({ color: '#ff0000' }) // for getStyle
       .mockReturnValueOnce({ color: '#00ff00' }); // for getTone
 
-    render(<QuestionPage />);
+    render(<MemoryRouter><QuestionPage /></MemoryRouter>);
     expect(screen.getByText('This is a test question')).toBeInTheDocument();
     expect(screen.getByText('Get more questions')).toBeInTheDocument();
   });
@@ -83,7 +84,7 @@ describe('QuestionPage', () => {
       .mockReturnValueOnce(null) // for getStyle
       .mockReturnValueOnce(null); // for getTone
 
-    render(<QuestionPage />);
+    render(<MemoryRouter><QuestionPage /></MemoryRouter>);
     expect(screen.getByText('Question with no style/tone')).toBeInTheDocument();
     expect(screen.getByText('Get more questions')).toBeInTheDocument();
   });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -19,6 +19,7 @@ const SettingsPage = () => {
   const [hiddenTones, setHiddenTones] = useLocalStorage<string[]>("hiddenTones", []);
   const [hiddenQuestions, setHiddenQuestions] = useLocalStorage<string[]>("hiddenQuestions", []);
   const [autoAdvanceShuffle, setAutoAdvanceShuffle] = useLocalStorage<boolean>("autoAdvanceShuffle", false);
+  const [bypassLandingPage, setBypassLandingPage] = useLocalStorage<boolean>("bypassLandingPage", false);
 
   const unhideStyle = (styleId: string) => {
     setHiddenStyles(prev => prev.filter(id => id !== styleId));
@@ -53,6 +54,24 @@ const SettingsPage = () => {
         <h1 className="text-3xl font-bold mb-6 dark:text-white text-black">Settings</h1>
 
         <div className="space-y-8">
+          <CollapsibleSection title="General" count={undefined}>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="dark:text-white text-black font-semibold">Bypass Landing Page</p>
+                <p className="text-sm dark:text-white/70 text-black/70">Go directly to the app when visiting the site.</p>
+              </div>
+              <button
+                onClick={() => setBypassLandingPage(!bypassLandingPage)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${bypassLandingPage ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
+                aria-pressed={bypassLandingPage}
+                aria-label="Toggle bypass landing page"
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${bypassLandingPage ? 'translate-x-6' : 'translate-x-1'}`}
+                />
+              </button>
+            </div>
+          </CollapsibleSection>
           <CollapsibleSection title="Shuffle" count={undefined}>
             <div className="flex items-center justify-between">
               <div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { ConvexReactClient } from "convex/react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
 import App from "./App";
+import Root from "./Root";
 import LikedQuestionsPage from "./app/liked/page";
 import AdminPage from "./app/admin/page";
 import QuestionsPage from "./app/admin/questions/page";
@@ -25,7 +26,8 @@ createRoot(document.getElementById("root")!).render(
     <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<App />} />
+          <Route path="/" element={<Root />} />
+          <Route path="/app" element={<App />} />
           <Route path="/question/:id" element={<QuestionPage />} />
           <Route path="/liked" element={<LikedQuestionsPage />} />
           <Route path="/settings" element={<SettingsPage />} />

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,38 @@
+import { Link } from "react-router-dom";
+import { MoveRight } from "lucide-react";
+
+const LandingPage = () => {
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-900 text-white">
+      <header className="p-4 flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Break the Ice</h1>
+      </header>
+
+      <main className="flex-1 flex flex-col items-center justify-center text-center p-4">
+        <h2 className="text-5xl font-bold mb-4">Welcome to Break the Ice</h2>
+        <p className="text-xl mb-8 text-gray-400">The fun way to start conversations and connect with people.</p>
+
+        <div className="w-full max-w-4xl bg-gray-800 rounded-lg shadow-lg aspect-video mb-8">
+          {/* Placeholder for the product showcase video */}
+          <div className="flex items-center justify-center h-full">
+            <p className="text-gray-500">Your product showcase video will be here.</p>
+          </div>
+        </div>
+
+        <Link
+          to="/app"
+          className="bg-purple-600 hover:bg-purple-700 text-white font-bold py-3 px-6 rounded-full text-lg transition-transform transform hover:scale-105 flex items-center"
+        >
+          Enter the App
+          <MoveRight className="ml-2" />
+        </Link>
+      </main>
+
+      <footer className="p-4 text-center text-gray-500">
+        <p>&copy; {new Date().getFullYear()} Break the Ice. All rights reserved.</p>
+      </footer>
+    </div>
+  );
+};
+
+export default LandingPage;


### PR DESCRIPTION
This commit introduces a new landing page for the application.

Key features include:
- A new landing page component at `src/pages/LandingPage.tsx`.
- A routing mechanism using a new `Root.tsx` component that checks for a `bypassLandingPage` flag in local storage. If the flag is true, the user is redirected to the main app at `/app`.
- A new toggle switch on the settings page to allow users to control the landing page bypass preference.
- Unit tests for the new routing logic have been added, and existing tests have been fixed to ensure compatibility.