### PR TITLE
I have successfully refactored `src/components/styles-selector/styles…

### DIFF
--- a/src/components/styles-selector/styles-selector.tsx
+++ b/src/components/styles-selector/styles-selector.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from 'convex/react';
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import { useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import {
   HelpCircle,
   GitBranch,
@@ -53,7 +53,7 @@ export interface StyleSelectorRef {
   cancelRandomizingStyle: () => void;
   confirmRandomizedStyle: () => void;
 }
-export const StyleSelector = forwardRef<StyleSelectorRef, StyleSelectorProps>(({ selectedStyle, onSelectStyle, onRandomizeStyle, randomOrder = true }, ref) => {
+export const StyleSelector = ({ selectedStyle, onSelectStyle, onRandomizeStyle, randomOrder = true, ref }: StyleSelectorProps & { ref?: React.Ref<StyleSelectorRef> }) => {
   const styles = useQuery(api.styles.getStyles);
   const [hiddenStyles, setHiddenStyles] = useLocalStorage<string[]>('hiddenStyles', []);
   const genericSelectorRef = useRef<GenericSelectorRef>(null);
@@ -106,4 +106,4 @@ export const StyleSelector = forwardRef<StyleSelectorRef, StyleSelectorProps>(({
       onRandomizeItem={onRandomizeStyle}
     />
   );
-});
+};

--- a/src/components/tone-selector/tone-selector.tsx
+++ b/src/components/tone-selector/tone-selector.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from 'convex/react';
-import { useRef, forwardRef, useImperativeHandle, useEffect, useMemo } from 'react';
+import { useRef, useImperativeHandle, useEffect, useMemo } from 'react';
 import { 
   Smile, 
   Brain, 
@@ -59,7 +59,7 @@ export interface ToneSelectorRef {
   confirmRandomizedTone: () => void;
 }
 
-export const ToneSelector = forwardRef<ToneSelectorRef, ToneSelectorProps>(({ selectedTone, onSelectTone, onRandomizeTone, randomOrder = true }, ref) => {
+export const ToneSelector = ({ selectedTone, onSelectTone, onRandomizeTone, randomOrder = true, ref }: ToneSelectorProps & { ref?: React.Ref<ToneSelectorRef> }) => {
   const tones = useQuery(api.tones.getTones);
   const [hiddenTones, setHiddenTones] = useLocalStorage<string[]>('hiddenTones', []);
   const genericSelectorRef = useRef<GenericSelectorRef>(null);
@@ -109,4 +109,4 @@ export const ToneSelector = forwardRef<ToneSelectorRef, ToneSelectorProps>(({ se
       onRandomizeItem={onRandomizeTone}
     />
   );
-});
+};


### PR DESCRIPTION
…-selector.tsx` to remove `forwardRef` and use the new `ref` prop pattern from React 19.

I have successfully refactored `src/components/tone-selector/tone-selector.tsx` to remove `forwardRef` and use the new `ref` prop pattern from React 19.