### PR TITLE
Refactor local storage to a reusable context hook

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -6,7 +6,7 @@ import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { useTheme } from "@/hooks/useTheme";
 import { Header } from "@/components/header";
-import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { useStorageContext } from "@/hooks/useStorageContext";
 import { Link } from "react-router-dom";
 import { cn, isColorDark } from "@/lib/utils";
 import { ErrorBoundary } from "../../components/ErrorBoundary";
@@ -14,7 +14,7 @@ import { QuestionList } from "@/components/question-list/QuestionList";
 
 function HistoryPageContent() {
   const { history, removeQuestionFromHistory, clearHistory } = useQuestionHistory();
-  const [likedQuestions, setLikedQuestions] = useLocalStorage<Id<"questions">[]>("likedQuestions", []);
+  const { likedQuestions, setLikedQuestions } = useStorageContext();
   const [searchText, setSearchText] = useState("");
   const recordAnalytics = useMutation(api.questions.recordAnalytics);
   const styles = useQuery(api.styles.getStyles, {});
@@ -124,9 +124,9 @@ function HistoryPageContent() {
   );
 }
 export default function HistoryPage() {
+  const { setQuestionHistory } = useStorageContext();
   const handleResetHistory = () => {
-    // Clear localStorage and reload the page
-    localStorage.removeItem("questionHistory");
+    setQuestionHistory([]);
     window.location.reload();
   };
 

--- a/src/app/liked/page.tsx
+++ b/src/app/liked/page.tsx
@@ -4,7 +4,7 @@ import { Doc, Id } from "../../../convex/_generated/dataModel";
 import { Link } from "react-router-dom";
 import { useTheme } from "../../hooks/useTheme";
 import { useMemo, useState, useEffect } from "react";
-import { useLocalStorage } from "../../hooks/useLocalStorage";
+import { useStorageContext } from "../../hooks/useStorageContext";
 import { ErrorBoundary } from "../../components/ErrorBoundary";
 import { QuestionList } from "@/components/question-list/QuestionList";
 
@@ -17,7 +17,7 @@ import { toast } from "sonner";
 function LikedQuestionsPageContent() {
   const { theme } = useTheme();
   const [searchText, setSearchText] = useState("");
-  const [likedQuestions, setLikedQuestions] = useLocalStorage<Id<"questions">[]>("likedQuestions", []);
+  const { likedQuestions, setLikedQuestions } = useStorageContext();
   const [isCleaningUp, setIsCleaningUp] = useState(false);
   
   // Filter out invalid question IDs to prevent errors
@@ -179,9 +179,9 @@ function LikedQuestionsPageContent() {
 }
 
 export default function LikedQuestionsPage() {
+  const { setLikedQuestions } = useStorageContext();
   const handleResetLikes = () => {
-    // Clear localStorage and reload the page
-    localStorage.removeItem("likedQuestions");
+    setLikedQuestions([]);
     window.location.reload();
   };
 

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { Id, Doc } from "../../../convex/_generated/dataModel";
 import { useTheme } from "../../hooks/useTheme";
-import { useLocalStorage } from "../../hooks/useLocalStorage";
+import { useStorageContext } from "../../hooks/useStorageContext";
 import { useQuestionHistory } from "../../hooks/useQuestionHistory";
 import { Header } from "../../components/header";
 import { useEffect } from "react";
@@ -16,7 +16,7 @@ export default function QuestionPage() {
   const navigate = useNavigate();
   const { theme, setTheme } = useTheme();
   const { addQuestionToHistory } = useQuestionHistory();
-  const [likedQuestions, setLikedQuestions] = useLocalStorage<Id<"questions">[]>("likedQuestions", []);
+  const { likedQuestions, setLikedQuestions } = useStorageContext();
   const recordAnalytics = useMutation(api.questions.recordAnalytics);
 
   const question = useQuery(api.questions.getQuestionById, id ? { id } : "skip");

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo } from "react";
-import { useLocalStorage } from "../../hooks/useLocalStorage";
+import { useStorageContext } from "../../hooks/useStorageContext";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { useTheme } from "../../hooks/useTheme";
@@ -19,9 +19,14 @@ const SettingsPage = () => {
   const toggleSection = (section: string) => {
     setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
   };
-  const [hiddenStyles, setHiddenStyles] = useLocalStorage<string[]>("hiddenStyles", []);
-  const [hiddenTones, setHiddenTones] = useLocalStorage<string[]>("hiddenTones", []);
-  const [bypassLandingPage, setBypassLandingPage] = useLocalStorage<boolean>("bypassLandingPage", false);
+  const {
+    hiddenStyles,
+    setHiddenStyles,
+    hiddenTones,
+    setHiddenTones,
+    bypassLandingPage,
+    setBypassLandingPage,
+  } = useStorageContext();
   
   const settings = useQuery(api.users.getSettings);
   const updateHiddenQuestions = useMutation(api.users.updateHiddenQuestions);

--- a/src/components/styles-selector/styles-selector.tsx
+++ b/src/components/styles-selector/styles-selector.tsx
@@ -2,7 +2,7 @@ import { useQuery } from 'convex/react';
 import { useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import { api } from '../../../convex/_generated/api';
 import { GenericSelector, type GenericSelectorRef, type SelectorItem } from '../generic-selector';
-import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useStorageContext } from '../../hooks/useStorageContext';
 import * as icons from '@/components/ui/icons';
 
 interface StyleSelectorProps {
@@ -21,7 +21,7 @@ export interface StyleSelectorRef {
 }
 export const StyleSelector = ({ selectedStyle, onSelectStyle, onRandomizeStyle, randomOrder = true, ref }: StyleSelectorProps & { ref?: React.Ref<StyleSelectorRef> }) => {
   const styles = useQuery(api.styles.getStyles);
-  const [hiddenStyles, setHiddenStyles] = useLocalStorage<string[]>('hiddenStyles', []);
+  const { hiddenStyles, setHiddenStyles } = useStorageContext();
   const genericSelectorRef = useRef<GenericSelectorRef>(null);
   
   const handleHideStyle = (styleId: string) => {

--- a/src/components/tone-selector/tone-selector.tsx
+++ b/src/components/tone-selector/tone-selector.tsx
@@ -2,7 +2,7 @@ import { useQuery } from 'convex/react';
 import { useRef, useImperativeHandle, useEffect, useMemo } from 'react';
 import { api } from '../../../convex/_generated/api';
 import { GenericSelector, type GenericSelectorRef, type SelectorItem } from '../generic-selector';
-import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useStorageContext } from '../../hooks/useStorageContext';
 
 interface ToneSelectorProps {
   selectedTone: string;
@@ -21,7 +21,7 @@ export interface ToneSelectorRef {
 
 export const ToneSelector = ({ selectedTone, onSelectTone, onRandomizeTone, randomOrder = true, ref }: ToneSelectorProps & { ref?: React.Ref<ToneSelectorRef> }) => {
   const tones = useQuery(api.tones.getTones);
-  const [hiddenTones, setHiddenTones] = useLocalStorage<string[]>('hiddenTones', []);
+  const { hiddenTones, setHiddenTones } = useStorageContext();
   const genericSelectorRef = useRef<GenericSelectorRef>(null);
   
   const handleHideTone = (toneId: string) => {

--- a/src/hooks/useQuestionHistory.ts
+++ b/src/hooks/useQuestionHistory.ts
@@ -1,4 +1,4 @@
-import { useLocalStorage } from "./useLocalStorage";
+import { useStorageContext } from "./useStorageContext";
 import { Doc, Id } from "../../convex/_generated/dataModel";
 import { useCallback, useEffect, useMemo } from "react";
 import { useQuery } from "convex/react";
@@ -25,7 +25,7 @@ const isValidQuestion = (questionEntry: any): questionEntry is HistoryEntry => {
 };
 
 export function useQuestionHistory() {
-  const [rawHistory, setRawHistory] = useLocalStorage<HistoryEntry[]>("questionHistory", []);
+  const { questionHistory: rawHistory, setQuestionHistory: setRawHistory } = useStorageContext();
   const historyIds = useMemo(() => rawHistory.filter(entry => entry.question).map(entry => entry.question._id), [rawHistory]);
   const questions = useQuery(api.questions.getQuestionsByIds, { ids: historyIds });
   // Filter out invalid questions

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,36 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import { useStorageContext } from './useStorageContext';
 
 type Theme = 'light' | 'dark';
 
 const THEME_CHANGE_EVENT = 'theme-change';
 
 export function useTheme() {
-  const [theme, setTheme] = useState<Theme>(() => {
-    // Check if we're in a browser environment
-    if (typeof window === 'undefined') {
-      return 'light'; // Default for SSR
-    }
-    
-    try {
-      const savedTheme = localStorage.getItem('theme');
-      if (savedTheme === 'light' || savedTheme === 'dark') {
-        return savedTheme as Theme;
-      }
-      // Use matchMedia with fallback for older browsers
-      if (window.matchMedia) {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      }
-      return 'light';
-    } catch (error) {
-      console.warn('Error accessing theme preferences:', error);
-      return 'light';
-    }
-  });
+  const { theme, setTheme } = useStorageContext();
 
   useEffect(() => {
-    // Only run in browser environment
     if (typeof window === 'undefined') return;
-    
+
     try {
       const root = window.document.documentElement;
       if (theme === 'dark') {
@@ -38,9 +18,6 @@ export function useTheme() {
       } else {
         root.classList.remove('dark');
       }
-      localStorage.setItem('theme', theme);
-      
-      // Dispatch theme change event
       window.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: theme }));
     } catch (error) {
       console.warn('Error setting theme:', error);
@@ -50,31 +27,13 @@ export function useTheme() {
   return { theme, setTheme };
 }
 
+import { useState } from 'react';
+
 export function useThemeListener() {
-  const [theme, setTheme] = useState<Theme>(() => {
-    // Check if we're in a browser environment
-    if (typeof window === 'undefined') {
-      return 'light'; // Default for SSR
-    }
-    
-    try {
-      const savedTheme = localStorage.getItem('theme');
-      if (savedTheme === 'light' || savedTheme === 'dark') {
-        return savedTheme as Theme;
-      }
-      // Use matchMedia with fallback for older browsers
-      if (window.matchMedia) {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      }
-      return 'light';
-    } catch (error) {
-      console.warn('Error accessing theme preferences:', error);
-      return 'light';
-    }
-  });
+  const { theme: initialTheme } = useStorageContext();
+  const [theme, setTheme] = useState<Theme>(initialTheme);
 
   useEffect(() => {
-    // Only run in browser environment
     if (typeof window === 'undefined') return;
     
     const handleThemeChange = (event: CustomEvent<Theme>) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { ConvexReactClient } from "convex/react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
+import { StorageProvider } from "./hooks/useStorageContext";
 import App from "./App";
 import Root from "./Root";
 import LikedQuestionsPage from "./app/liked/page";
@@ -24,11 +25,12 @@ const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-  <ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
-    <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Root />} />
+    <ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
+      <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
+        <StorageProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Root />} />
           <Route path="/app" element={<App />} />
           <Route path="/question/:id" element={<QuestionPage />} />
           <Route path="/liked" element={<LikedQuestionsPage />} />
@@ -44,6 +46,7 @@ createRoot(document.getElementById("root")!).render(
           <Route path="/admin/questions/:id" element={<IndividualQuestionPage />} />
         </Routes>
       </BrowserRouter>
+    </StorageProvider>
     </ConvexProviderWithClerk>
   </ClerkProvider>
   </StrictMode>,

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { Doc, Id } from "../../convex/_generated/dataModel";
 import { useTheme } from "../hooks/useTheme";
-import { useLocalStorage } from "../hooks/useLocalStorage";
+import { useStorageContext } from "../hooks/useStorageContext";
 import { useQuestionHistory } from "../hooks/useQuestionHistory";
 import { StyleSelector, StyleSelectorRef } from "../components/styles-selector";
 import { ToneSelector, ToneSelectorRef } from "../components/tone-selector";
@@ -19,9 +19,12 @@ import { isColorDark } from "@/lib/utils";
 export default function MainPage() {
   const { theme } = useTheme();
 
-  // For migration
-  const [likedQuestions, setLikedQuestions] = useLocalStorage<Id<"questions">[]>("likedQuestions", []);
-  const [hiddenQuestions, setHiddenQuestions] = useLocalStorage<Id<"questions">[]>("hiddenQuestions", []);
+  const {
+    likedQuestions,
+    setLikedQuestions,
+    hiddenQuestions,
+    setHiddenQuestions,
+  } = useStorageContext();
 
 
 


### PR DESCRIPTION
This commit refactors all direct usages of `localStorage` into a reusable React context hook called `useStorageContext`.

- Created `src/hooks/useStorageContext.tsx` to provide a `StorageProvider` and `useStorageContext` hook.
- Centralized all `localStorage` access for `theme`, `likedQuestions`, `questionHistory`, `hiddenQuestions`, `hiddenStyles`, `hiddenTones`, and `bypassLandingPage` into the `useStorageContext`.
- Refactored all components and hooks that were previously using `useLocalStorage` or direct `localStorage` access to use the new `useStorageContext` hook.
- Removed the `useLocalStorage.ts` hook as it is no longer needed.