### PR TITLE
Fix main page undefined map error

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,7 +6,21 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function isColorDark(color: string) {
-  const [r, g, b] = color.match(/\w\w/g)!.map(hex => parseInt(hex, 16));
-  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-  return brightness < 128;
+  // Fallback for invalid input
+  try {
+    if (typeof color !== 'string') return false;
+    // Normalize hex color, support formats like #RGB, #RRGGBB
+    let hex = color.trim().replace('#', '');
+    if (hex.length === 3) {
+      hex = hex.split('').map((ch) => ch + ch).join('');
+    }
+    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
+      return false;
+    }
+    const [r, g, b] = hex.match(/\w\w/g)!.map((h) => parseInt(h, 16));
+    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+    return brightness < 128;
+  } catch {
+    return false;
+  }
 };


### PR DESCRIPTION
Add robust input validation to `isColorDark` to prevent `TypeError: Cannot read properties of undefined (reading 'map')` when processing invalid color strings.

---
<a href="https://cursor.com/background-agent?bcId=bc-355148ef-d0a7-4398-8037-b3232c1afaa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-355148ef-d0a7-4398-8037-b3232c1afaa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

