### PR TITLE
fix: Handle empty AI response in duplicate detection

### DIFF
--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -433,6 +433,10 @@ ${JSON.stringify(questions.map(q => ({ id: q._id, text: q.text, style: q.style }
       cleanedResponse = jsonMatch[0];
     }
 
+    if (!cleanedResponse) {
+      // If the cleaned response is empty, there are no duplicates.
+      return [];
+    }
     const duplicateGroups = JSON.parse(cleanedResponse);
     
     if (!Array.isArray(duplicateGroups)) {


### PR DESCRIPTION
Adds a check to ensure the cleaned response from the AI is not empty before attempting to parse it as JSON in the `detectDuplicatesInBatch` function. This prevents an 'Unexpected end of JSON input' error when the AI returns a response that becomes an empty string after cleaning (e.g., a response containing only markdown).