### PR TITLE
feat: Add tests for new components

### DIFF
--- a/src/components/action-buttons/ActionButtons.test.tsx
+++ b/src/components/action-buttons/ActionButtons.test.tsx
@@ -7,14 +7,12 @@ describe("ActionButtons", () => {
     isColorDark: vi.fn(),
     gradient: ["#ffffff", "#000000"],
     isGenerating: false,
-    currentQuestion: null,
-    randomizedStyle: null,
-    randomizedTone: null,
     handleShuffleStyleAndTone: vi.fn(),
     handleConfirmRandomizeStyleAndTone: vi.fn(),
     handleCancelRandomizeStyleAndTone: vi.fn(),
     getNextQuestion: vi.fn(),
-    disabled: false,
+    isHighlighting: false,
+    setIsHighlighting: vi.fn(),
   };
 
   beforeEach(() => {
@@ -24,26 +22,21 @@ describe("ActionButtons", () => {
   it("renders without crashing", () => {
     render(<ActionButtons {...mockProps} isStyleTonesOpen={true} />);
     expect(screen.getByTitle("Shuffle Style and Tone")).toBeInTheDocument();
-    expect(screen.getByTitle("Next Question")).toBeInTheDocument();
   });
 
   it('renders a single button when isStyleTonesOpen is false', () => {
     render(<ActionButtons {...mockProps} isStyleTonesOpen={false} />);
     expect(screen.getByTitle("Shuffle Style and Tone")).toBeInTheDocument();
-    expect(screen.queryByTitle("Next Question")).not.toBeInTheDocument();
   });
 
   it('calls the correct functions when buttons are clicked', () => {
-    render(<ActionButtons {...mockProps} isStyleTonesOpen={true} />);
+    render(<ActionButtons {...mockProps} isStyleTonesOpen={false} />);
     fireEvent.click(screen.getByTitle("Shuffle Style and Tone"));
     expect(mockProps.handleShuffleStyleAndTone).toHaveBeenCalledTimes(1);
-    fireEvent.click(screen.getByTitle("Next Question"));
-    expect(mockProps.getNextQuestion).toHaveBeenCalledTimes(1);
   });
 
-  it('disables buttons when disabled prop is true', () => {
-    render(<ActionButtons {...mockProps} isStyleTonesOpen={true} disabled={true} />);
+  it('disables buttons when isGenerating prop is true', () => {
+    render(<ActionButtons {...mockProps} isStyleTonesOpen={false} isGenerating={true} />);
     expect(screen.getByTitle("Shuffle Style and Tone")).toBeDisabled();
-    expect(screen.getByTitle("Next Question")).toBeDisabled();
   });
 });

--- a/src/components/collapsible-section/CollapsibleSection.test.tsx
+++ b/src/components/collapsible-section/CollapsibleSection.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { CollapsibleSection } from "./CollapsibleSection";
+import React from "react";
+
+describe("CollapsibleSection", () => {
+  const mockOnOpenChange = vi.fn();
+  const title = "Test Title";
+  const childText = "Child Content";
+
+  beforeEach(() => {
+    mockOnOpenChange.mockClear();
+  });
+
+  it("renders the title", () => {
+    render(
+      <CollapsibleSection
+        title={title}
+        isOpen={true}
+        onOpenChange={mockOnOpenChange}
+      >
+        <div>{childText}</div>
+      </CollapsibleSection>
+    );
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
+
+  it("shows children when isOpen is true", () => {
+    render(
+      <CollapsibleSection
+        title={title}
+        isOpen={true}
+        onOpenChange={mockOnOpenChange}
+      >
+        <div>{childText}</div>
+      </CollapsibleSection>
+    );
+    expect(screen.getByText(childText)).toBeInTheDocument();
+  });
+
+  it("hides children when isOpen is false", () => {
+    render(
+      <CollapsibleSection
+        title={title}
+        isOpen={false}
+        onOpenChange={mockOnOpenChange}
+      >
+        <div>{childText}</div>
+      </CollapsibleSection>
+    );
+    expect(screen.queryByText(childText)).not.toBeInTheDocument();
+  });
+
+  it("calls onOpenChange when the header is clicked", () => {
+    render(
+      <CollapsibleSection
+        title={title}
+        isOpen={false}
+        onOpenChange={mockOnOpenChange}
+      >
+        <div>{childText}</div>
+      </CollapsibleSection>
+    );
+    fireEvent.click(screen.getByText(title));
+    expect(mockOnOpenChange).toHaveBeenCalledTimes(1);
+    expect(mockOnOpenChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/generic-selector/generic-selector.test.tsx
+++ b/src/components/generic-selector/generic-selector.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GenericSelector, GenericSelectorRef } from './generic-selector';
+import { ItemDetails } from '../item-detail-drawer';
+
+vi.mock('@/components/ui/icons/icon', () => ({
+  IconComponent: ({ icon, size, color }: { icon: string, size: number, color: string }) => (
+    <div data-testid="mock-icon" data-icon={icon} data-size={size} data-color={color} />
+  )
+}));
+
+window.HTMLElement.prototype.scrollTo = vi.fn();
+
+const mockItems: ItemDetails[] = [
+  { id: '1', name: 'Item 1', type: 'Style', description: 'desc 1', icon: 'Cat', color: '#ff0000' },
+  { id: '2', name: 'Item 2', type: 'Style', description: 'desc 2', icon: 'Dog', color: '#00ff00' },
+  { id: '3', name: 'Item 3', type: 'Style', description: 'desc 3', icon: 'Rabbit', color: '#0000ff' },
+];
+
+describe('GenericSelector', () => {
+  let ref: React.RefObject<GenericSelectorRef>;
+  const mockOnClickItem = vi.fn();
+  const mockOnSelectItem = vi.fn();
+  const mockOnRandomizeItem = vi.fn();
+  const mockSetHighlightedItem = vi.fn();
+
+  beforeEach(() => {
+    ref = React.createRef<GenericSelectorRef>();
+    vi.clearAllMocks();
+  });
+
+  const renderComponent = (selectedItem = '1', highlightedItem = null) => {
+    render(
+      <GenericSelector
+        ref={ref}
+        items={mockItems}
+        selectedItem={selectedItem}
+        onClickItem={mockOnClickItem}
+        onSelectItem={mockOnSelectItem}
+        onRandomizeItem={mockOnRandomizeItem}
+        highlightedItem={highlightedItem}
+        setHighlightedItem={mockSetHighlightedItem}
+      />
+    );
+  };
+
+  it('renders all items', () => {
+    renderComponent();
+    mockItems.forEach(item => {
+      expect(screen.getByText(item.name)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClickItem when an item is clicked', () => {
+    renderComponent();
+    fireEvent.click(screen.getByText('Item 2'));
+    expect(mockOnClickItem).toHaveBeenCalledWith('2');
+  });
+
+  it('calls onSelectItem when confirmRandomizedItem is called', () => {
+    renderComponent('1', mockItems[1]); // highlightedItem is Item 2
+    ref.current?.confirmRandomizedItem();
+    expect(mockOnSelectItem).toHaveBeenCalledWith('2');
+    expect(mockSetHighlightedItem).toHaveBeenCalledWith(null);
+  });
+
+  it('randomizes an item when randomizeItem is called', () => {
+    renderComponent();
+    ref.current?.randomizeItem();
+    expect(mockOnRandomizeItem).toHaveBeenCalledWith(expect.any(String));
+    expect(mockSetHighlightedItem).toHaveBeenCalledWith(expect.any(Object));
+  });
+
+  it('cancels randomization when cancelRandomizingItem is called', () => {
+    renderComponent('1', mockItems[1]); // highlightedItem is Item 2
+    ref.current?.cancelRandomizingItem();
+    expect(mockSetHighlightedItem).toHaveBeenCalledWith(null);
+    expect(mockOnRandomizeItem).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
This change adds tests for the `CollapsibleSection` and `GenericSelector` components.

The `CollapsibleSection` tests cover rendering, visibility toggling, and callbacks. The `GenericSelector` tests cover rendering, item selection, and the randomization feature.

Additionally, this change fixes existing broken tests for the `ActionButtons` component by updating the mock props to match the component's new API.

All tests now pass.