### PR TITLE
Fix: Prevent card animation on question generation

### DIFF
--- a/src/components/question-display/QuestionDisplay.tsx
+++ b/src/components/question-display/QuestionDisplay.tsx
@@ -65,7 +65,6 @@ export const QuestionDisplay = ({
   };
   return (
     <motion.div
-      key={currentQuestion?._id}
       className="flex-1 flex items-center justify-center px-5 pb-8"
       initial={{ x: 0, y:-300, opacity: 0 }}
       animate={{ x: 0, y:0, opacity: 1 }}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -40,6 +40,7 @@ export default function MainPage() {
   const { addQuestionHistoryEntry } = useQuestionHistory();
   const [startTime, setStartTime] = useState(Date.now());
   const [isGenerating, setIsGenerating] = useState(false);
+  const [generationKey, setGenerationKey] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedStyle, setSelectedStyle] = useState(searchParams.get("style") ?? styles?.[0]?.id ?? "");
   const [selectedTone, setSelectedTone] = useState(searchParams.get("tone") ?? tones?.[0]?.id ?? "");
@@ -153,6 +154,7 @@ export default function MainPage() {
           });
         } else if ((currentQuestions.length === 0) && !isGenerating) {
           setIsGenerating(true);
+          setGenerationKey(Date.now().toString());
           // Generate only 1 question when shuffling, 2 otherwise
           const count = isShuffling ? 1 : 2;
           // console.log("First useEffect triggering generation:", { count, isShuffling, isShufflingRef: isShufflingRef.current });
@@ -254,6 +256,7 @@ export default function MainPage() {
         // If we're about to remove the last question and no generation is in progress, start generating
         if (newQuestions.length === 0 && !isGenerating) {
           setIsGenerating(true);
+          setGenerationKey(Date.now().toString());
           // Generate questions immediately to prevent empty state
           const count = isShuffling ? 1 : 2;
           const timeout = setTimeout(() => {
@@ -317,6 +320,7 @@ export default function MainPage() {
 
   const getNextQuestion = () => {
     try {
+      setGenerationKey(null);
       setStartTime(Date.now());
       // Reset shuffle ref when user manually advances
       isShufflingRef.current = false;
@@ -423,7 +427,7 @@ export default function MainPage() {
         <AnimatePresence mode="wait">
           {currentQuestion && selectedStyle && selectedTone ? (
             <QuestionDisplay
-              key={currentQuestion._id}
+              key={generationKey ?? currentQuestion._id}
               isGenerating={isGenerating}
               currentQuestion={currentQuestion}
               isFavorite={isFavorite}
@@ -435,7 +439,7 @@ export default function MainPage() {
             />
           ) : (
             <QuestionDisplay
-              key="loading"
+              key={generationKey ?? "loading"}
               isGenerating={true}
               currentQuestion={null}
               isFavorite={false}


### PR DESCRIPTION
The card component was animating out and in when a new question was generated. This was caused by the `key` prop of the `QuestionDisplay` component changing from a loading state key to the new question's ID, which triggered an unmount and remount cycle within the `AnimatePresence` component.

This change introduces a `generationKey` state variable. This key is created when a generation cycle begins and is used for both the loading card and the resulting question card. This ensures the key remains stable throughout the generation process, preventing the animation. The `generationKey` is reset when the user manually navigates to the next question, preserving the intended animation for normal discards.