### PR TITLE
feat: Pass gradient from MainPage to prevent flicker

### DIFF
--- a/src/components/action-buttons/ActionButtons.tsx
+++ b/src/components/action-buttons/ActionButtons.tsx
@@ -132,7 +132,7 @@ export const ActionButtons = ({
                 : "bg-black/20 dark:bg-black/20",
               "px-5 py-3 rounded-full flex justify-center items-center gap-2 hover:bg-black/30 dark:hover:bg-white/30 transition-colors"
             )}
-            title="Shuffle Style and Tone"
+            title="Next Question"
             disabled={isGenerating}
           >
             <GradientArrowRightIcon size={24} gradient={gradient} />

--- a/src/components/modern-question-card/modern-question-card.tsx
+++ b/src/components/modern-question-card/modern-question-card.tsx
@@ -11,6 +11,7 @@ interface ModernQuestionCardProps {
   question: Doc<"questions"> | null;
   isGenerating: boolean;
   isFavorite: boolean;
+  gradient: string[];
   onToggleFavorite: () => void;
   onToggleHidden: () => void;
   onShare?: () => void;
@@ -23,6 +24,7 @@ export function ModernQuestionCard({
   question,
   isGenerating,
   isFavorite,
+  gradient,
   onToggleFavorite,
   onToggleHidden,
   onHideStyle,
@@ -34,9 +36,6 @@ export function ModernQuestionCard({
   const tone = useQuery(api.tones.getTone, (!question || question?.tone === "") ? "skip" : { id: question?.tone as string ?? "fun-silly" });
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [selectedItemForDrawer, setSelectedItemForDrawer] = useState<ItemDetails | null>(null);
-  const gradient = useMemo(() => {
-    return [style?.color || '#667EEA', tone?.color || '#764BA2'];
-  }, [style, tone]);
  
   const handleHideStyle = (itemId: string) => {
     if (!style) return;

--- a/src/components/question-display/QuestionDisplay.tsx
+++ b/src/components/question-display/QuestionDisplay.tsx
@@ -7,6 +7,7 @@ interface QuestionDisplayProps {
   isGenerating: boolean;
   currentQuestion: Doc<"questions"> | null;
   isFavorite: boolean;
+  gradient: string[];
   toggleLike: (questionId: any) => void;
   onSwipe: () => void;
   toggleHide: (questionId: any) => void;
@@ -19,6 +20,7 @@ export const QuestionDisplay = ({
   isGenerating,
   currentQuestion,
   isFavorite,
+  gradient,
   toggleLike,
   onSwipe,
   toggleHide,
@@ -82,6 +84,7 @@ export const QuestionDisplay = ({
         isGenerating={isGenerating}
         question={currentQuestion}
         isFavorite={isFavorite}
+        gradient={gradient}
         onToggleFavorite={() => currentQuestion && toggleLike(currentQuestion._id)}
         onToggleHidden={() => currentQuestion && toggleHide(currentQuestion._id)}
         onHideStyle={handleHideStyle}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -433,6 +433,7 @@ export default function MainPage() {
             isGenerating={!currentQuestion || isGenerating}
             currentQuestion={currentQuestion}
             isFavorite={isFavorite}
+            gradient={gradient}
             toggleLike={currentQuestion ? () => toggleLike(currentQuestion._id) : () => {}}
             onSwipe={getNextQuestion}
             toggleHide={currentQuestion ? () => toggleHide(currentQuestion._id) : () => {}}


### PR DESCRIPTION
The border gradient on the question card would flicker to the default color whenever a new question was being generated. This was because the `ModernQuestionCard` component was responsible for fetching the style/tone and calculating its own gradient based on the current question. When the question was null during generation, it would fall back to a default.

To fix this, the `gradient` is now calculated in `MainPage` and passed down through `QuestionDisplay` to `ModernQuestionCard`. This ensures the gradient remains consistent and prevents the flicker.

fix(tests): Correct button title in ActionButtons

Also fixed a bug in the `ActionButtons` component where two buttons had the same title, causing tests to fail. The "Next" button now has the title "Next Question", which is more accurate and resolves the test failures.