### PR TITLE
Feat: Implement toggles for styles and tones in settings

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import { CollapsibleSection } from "../../components/collapsible-section/Collaps
 import { Header } from "@/components/header";
 import { Id } from "../../../convex/_generated/dataModel";
 import { useState } from "react";
+import DynamicIcon from "@/components/ui/dynamic-icon";
 
 const SettingsPage = () => {
   const { effectiveTheme } = useTheme();
@@ -156,7 +157,10 @@ const SettingsPage = () => {
                     const isIncluded = !hiddenStyles.includes(style.id);
                     return (
                       <li key={style.id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
-                        <span className="dark:text-white text-black">{style.name}</span>
+                        <div className="flex items-center">
+                          <DynamicIcon name={style.icon} color={style.color} size={24} className="mr-2" />
+                          <span className="dark:text-white text-black">{style.name}</span>
+                        </div>
                         <button
                           onClick={() => handleToggleStyle(style.id)}
                           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isIncluded ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
@@ -204,7 +208,10 @@ const SettingsPage = () => {
                     const isIncluded = !hiddenTones.includes(tone.id);
                     return (
                       <li key={tone.id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
-                        <span className="dark:text-white text-black">{tone.name}</span>
+                        <div className="flex items-center">
+                          <DynamicIcon name={tone.icon} color={tone.color} size={24} className="mr-2" />
+                          <span className="dark:text-white text-black">{tone.name}</span>
+                        </div>
                         <button
                           onClick={() => handleToggleTone(tone.id)}
                           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isIncluded ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -22,12 +22,12 @@ const SettingsPage = () => {
   const {
     hiddenStyles,
     setHiddenStyles,
+    addHiddenStyle,
     removeHiddenStyle,
-    clearHiddenStyles,
     hiddenTones,
     setHiddenTones,
+    addHiddenTone,
     removeHiddenTone,
-    clearHiddenTones,
     hiddenQuestions,
     setHiddenQuestions,
     removeHiddenQuestion,
@@ -35,23 +35,26 @@ const SettingsPage = () => {
     bypassLandingPage,
     setBypassLandingPage,
   } = useStorageContext();
-  
 
-  const unhideStyle = (styleId: string) => {
-    removeHiddenStyle(styleId);
+  const handleToggleStyle = (styleId: string) => {
+    if (hiddenStyles.includes(styleId)) {
+      removeHiddenStyle(styleId);
+    } else {
+      addHiddenStyle(styleId);
+    }
   };
 
-  const unhideTone = (toneId: string) => {
-    removeHiddenTone(toneId);
+  const handleToggleTone = (toneId: string) => {
+    if (hiddenTones.includes(toneId)) {
+      removeHiddenTone(toneId);
+    } else {
+      addHiddenTone(toneId);
+    }
   };
 
   const unhideQuestion = (questionId: Id<"questions">) => {
     removeHiddenQuestion(questionId);
   };
-
-
-  const hiddenStyleObjects = allStyles?.filter(style => hiddenStyles.includes(style.id));
-  const hiddenToneObjects = allTones?.filter(tone => hiddenTones.includes(tone.id));
   const hiddenQuestionObjects = useQuery(api.questions.getQuestionsByIds, { ids: hiddenQuestions });
 
 
@@ -127,68 +130,98 @@ const SettingsPage = () => {
             </div>
           </CollapsibleSection>
           <CollapsibleSection
-            title="Hidden Styles"
-            isOpen={!!openSections['hidden-styles']}
-            onOpenChange={() => toggleSection('hidden-styles')}
-            count={hiddenStyleObjects?.length}
+            title="Manage Styles"
+            isOpen={!!openSections['manage-styles']}
+            onOpenChange={() => toggleSection('manage-styles')}
+            count={allStyles?.length}
           >
-            {hiddenStyleObjects && hiddenStyleObjects.length > 0 ? (
+            {allStyles && allStyles.length > 0 ? (
               <>
-                <button
-                  onClick={clearHiddenStyles}
-                  className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors mb-4"
-                >
-                  Clear All
-                </button>
+                <div className="flex space-x-2 mb-4">
+                  <button
+                    onClick={() => setHiddenStyles([])}
+                    className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
+                  >
+                    Include All
+                  </button>
+                  <button
+                    onClick={() => setHiddenStyles(allStyles.map(s => s.id))}
+                    className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
+                  >
+                    Hide All
+                  </button>
+                </div>
                 <ul className="space-y-2">
-                  {hiddenStyleObjects.map(style => (
-                    <li key={style.id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
-                      <span className="dark:text-white text-black">{style.name}</span>
-                      <button
-                        onClick={() => unhideStyle(style.id)}
-                        className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
-                      >
-                        Unhide
-                      </button>
-                    </li>
-                  ))}
+                  {allStyles.map(style => {
+                    const isIncluded = !hiddenStyles.includes(style.id);
+                    return (
+                      <li key={style.id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
+                        <span className="dark:text-white text-black">{style.name}</span>
+                        <button
+                          onClick={() => handleToggleStyle(style.id)}
+                          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isIncluded ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
+                          aria-pressed={isIncluded}
+                          aria-label={`Toggle style ${style.name}`}
+                        >
+                          <span
+                            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isIncluded ? 'translate-x-6' : 'translate-x-1'}`}
+                          />
+                        </button>
+                      </li>
+                    );
+                  })}
                 </ul>
               </>
             ) : (
-              <p className="dark:text-white/70 text-black/70">You have no hidden styles.</p>
+              <p className="dark:text-white/70 text-black/70">No styles available to manage.</p>
             )}
           </CollapsibleSection>
 
           <CollapsibleSection
-            title="Hidden Tones"
-            isOpen={!!openSections['hidden-tones']}
-            onOpenChange={() => toggleSection('hidden-tones')}
-            count={hiddenToneObjects?.length}
+            title="Manage Tones"
+            isOpen={!!openSections['manage-tones']}
+            onOpenChange={() => toggleSection('manage-tones')}
+            count={allTones?.length}
           >
-            {hiddenToneObjects && hiddenToneObjects.length > 0 ? (
+            {allTones && allTones.length > 0 ? (
               <>
-                <button
-                  onClick={clearHiddenTones}
-                  className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors mb-4"
-                >
-                  Clear All
-                </button>
+                <div className="flex space-x-2 mb-4">
+                  <button
+                    onClick={() => setHiddenTones([])}
+                    className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
+                  >
+                    Include All
+                  </button>
+                  <button
+                    onClick={() => setHiddenTones(allTones.map(t => t.id))}
+                    className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
+                  >
+                    Hide All
+                  </button>
+                </div>
                 <ul className="space-y-2">
-                  {hiddenToneObjects.map(tone => (
-                    <li key={tone.id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
-                      <span className="dark:text-white text-black">{tone.name}</span>
-                      <button
-                        onClick={() => unhideTone(tone.id)}
-                        className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
-                      >
-                        Unhide
-                      </button>
-                    </li>
-                  ))}
+                  {allTones.map(tone => {
+                    const isIncluded = !hiddenTones.includes(tone.id);
+                    return (
+                      <li key={tone.id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
+                        <span className="dark:text-white text-black">{tone.name}</span>
+                        <button
+                          onClick={() => handleToggleTone(tone.id)}
+                          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isIncluded ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
+                          aria-pressed={isIncluded}
+                          aria-label={`Toggle tone ${tone.name}`}
+                        >
+                          <span
+                            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isIncluded ? 'translate-x-6' : 'translate-x-1'}`}
+                          />
+                        </button>
+                      </li>
+                    );
+                  })}
                 </ul>
               </>
             ) : (
-              <p className="dark:text-white/70 text-black/70">You have no hidden tones.</p>
+              <p className="dark:text-white/70 text-black/70">No tones available to manage.</p>
             )}
           </CollapsibleSection>
 

--- a/src/components/ui/dynamic-icon.tsx
+++ b/src/components/ui/dynamic-icon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { icons } from 'lucide-react';
+import { LucideProps } from 'lucide-react';
+
+interface DynamicIconProps extends LucideProps {
+  name: string;
+}
+
+const toPascalCase = (str: string) => {
+  return str.replace(/(^\w|-\w)/g, (text) => text.replace(/-/, "").toUpperCase());
+};
+
+const DynamicIcon: React.FC<DynamicIconProps> = ({ name, ...props }) => {
+  const iconName = toPascalCase(name);
+  // @ts-expect-error - We are using a dynamic name to access the icon
+  const LucideIcon = icons[iconName];
+
+  if (!LucideIcon) {
+    // You can return a default icon or null
+    return null;
+  }
+
+  return <LucideIcon {...props} />;
+};
+
+export default DynamicIcon;

--- a/src/components/ui/dynamic-icon.tsx
+++ b/src/components/ui/dynamic-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { icons } from 'lucide-react';
+import { icons, Circle } from 'lucide-react';
 import { LucideProps } from 'lucide-react';
 
 interface DynamicIconProps extends LucideProps {
@@ -7,17 +7,27 @@ interface DynamicIconProps extends LucideProps {
 }
 
 const toPascalCase = (str: string) => {
-  return str.replace(/(^\w|-\w)/g, (text) => text.replace(/-/, "").toUpperCase());
+  return str
+    .replace(/([-_][a-z])/g, (group) =>
+      group.toUpperCase().replace('-', '').replace('_', '')
+    )
+    .replace(/^[a-z]/, (char) => char.toUpperCase());
 };
 
 const DynamicIcon: React.FC<DynamicIconProps> = ({ name, ...props }) => {
-  const iconName = toPascalCase(name);
+  let iconName = toPascalCase(name);
+
+  // Special case for HelpCircle -> CircleHelp
+  if (iconName === 'HelpCircle') {
+    iconName = 'CircleHelp';
+  }
+
   // @ts-expect-error - We are using a dynamic name to access the icon
   const LucideIcon = icons[iconName];
 
   if (!LucideIcon) {
-    // You can return a default icon or null
-    return null;
+    // Fallback to a default icon
+    return <Circle {...props} />;
   }
 
   return <LucideIcon {...props} />;


### PR DESCRIPTION
This commit refactors the settings page to display all available styles and tones with toggle switches to control their visibility.

The 'Hidden Styles' and 'Hidden Tones' sections have been replaced with 'Manage Styles' and 'Manage Tones' sections.

Each style and tone is listed with a toggle switch. An enabled toggle means the item is included, and a disabled toggle means it's hidden. The hidden items are stored in local storage.

'Include All' and 'Hide All' buttons have been added for convenience.