### PR TITLE
feat: Limit liked, history, and hidden items to 100

### DIFF
--- a/src/hooks/useQuestionHistory.ts
+++ b/src/hooks/useQuestionHistory.ts
@@ -4,8 +4,6 @@ import { useCallback, useEffect, useMemo } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 
-const MAX_HISTORY_LENGTH = 100;
-
 export type HistoryEntry = {
   question: Doc<"questions">;
   viewedAt: number;

--- a/src/hooks/useStorageContext.tsx
+++ b/src/hooks/useStorageContext.tsx
@@ -3,6 +3,8 @@ import { Id } from "../../convex/_generated/dataModel";
 import { HistoryEntry } from "./useQuestionHistory";
 import { useLocalStorage } from "./useLocalStorage";
 
+const MAX_ITEMS = 100;
+
 type Theme = "light" | "dark" | "system";
 
 interface StorageContextType {
@@ -67,7 +69,17 @@ export const StorageProvider = ({ children }: { children: ReactNode }) => {
   );
 
   const addLikedQuestion = useCallback((id: Id<"questions">) => {
-    setLikedQuestions(prev => [...prev, id]);
+    setLikedQuestions(prev => {
+      if (prev.length >= MAX_ITEMS) {
+        const confirmed = window.confirm("You have reached the maximum number of liked questions. Do you want to remove the oldest item to add this new one?");
+        if (confirmed) {
+          return [...prev.slice(1), id];
+        } else {
+          return prev;
+        }
+      }
+      return [...prev, id];
+    });
   }, [setLikedQuestions]);
   const removeLikedQuestion = useCallback((id: Id<"questions">) => {
     setLikedQuestions(prev => prev.filter(questionId => questionId !== id));
@@ -88,14 +100,34 @@ export const StorageProvider = ({ children }: { children: ReactNode }) => {
   }, [setHiddenTones]);
 
   const addQuestionToHistory = useCallback((entry: HistoryEntry) => {
-    setQuestionHistory(prev => [entry, ...prev]);
+    setQuestionHistory(prev => {
+      if (prev.length >= MAX_ITEMS) {
+        const confirmed = window.confirm("You have reached the maximum number of history items. Do you want to remove the oldest item to add this new one?");
+        if (confirmed) {
+          return [entry, ...prev.slice(0, -1)];
+        } else {
+          return prev;
+        }
+      }
+      return [entry, ...prev];
+    });
   }, [setQuestionHistory]);
   const removeQuestionFromHistory = useCallback((id: Id<"questions">) => {
     setQuestionHistory(prev => prev.filter(entry => entry.question && entry.question._id !== id));
   }, [setQuestionHistory]);
   
   const addHiddenQuestion = useCallback((id: Id<"questions">) => {
-    setHiddenQuestions(prev => [...prev, id]);
+    setHiddenQuestions(prev => {
+      if (prev.length >= MAX_ITEMS) {
+        const confirmed = window.confirm("You have reached the maximum number of hidden questions. Do you want to remove the oldest item to add this new one?");
+        if (confirmed) {
+          return [...prev.slice(1), id];
+        } else {
+          return prev;
+        }
+      }
+      return [...prev, id];
+    });
   }, [setHiddenQuestions]);
   const removeHiddenQuestion = useCallback((id: Id<"questions">) => {
     setHiddenQuestions(prev => prev.filter(questionId => questionId !== id));


### PR DESCRIPTION
This commit introduces a limit of 100 items for the liked, history, and hidden questions lists.

When any of these lists reach the 100-item limit, the user is prompted with a confirmation dialog before the oldest item is replaced with the new one.

The changes are implemented in `useStorageContext.tsx` to centralize the logic.