### PR TITLE
Implement minimum questions generation for style/tone combinations

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -11,4 +11,12 @@ crons.interval(
   { batchSize: 50 }
 );
 
+// Run daily question generation to ensure minimum 10 questions per style/tone combination
+crons.interval(
+  "ensure minimum questions per combination",
+  { hours: 24 }, // Run daily to process combinations gradually
+  internal.ai.ensureMinimumQuestionsPerCombination,
+  { minimumCount: 10, maxCombinations: 3 } // Process only 3 combinations per cron run to avoid timeout
+);
+
 export default crons;


### PR DESCRIPTION
This commit introduces a new internal action, `ensureMinimumQuestionsPerCombination`, which ensures that a minimum number of questions are generated for each style/tone combination. Additionally, a public action, `testMinimumQuestionsGeneration`, is added for manual testing of this functionality. The cron job is updated to run daily, processing a limited number of combinations to avoid timeouts. Furthermore, a new internal query, `getQuestionCountsByStyleAndTone`, is implemented to retrieve question counts by style and tone, enhancing monitoring capabilities. These changes improve the question generation process and maintain a balanced distribution across styles and tones.