### PR TITLE
Fix: Ensure error propagation on complete AI generation failure

### DIFF
--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -302,10 +302,14 @@ Respond with ONLY the JSON array, no other text.`
         }
       } catch (fallbackError) {
         console.error("Fallback generation also failed:", fallbackError);
+        // If the fallback also fails, we want to throw the original error.
+        // We'll fall through to the throw statement below.
       }
       
-      // Return empty array on complete failure
-      return [];
+      // If we got to this point, the primary generation failed and the fallback
+      // either failed or did not produce a question. In either case, we should
+      // throw the original error to notify the client.
+      throw error;
     }
   },
 });


### PR DESCRIPTION
When the `generateAIQuestion` action failed to generate a question, including after a fallback attempt, it would return an empty array instead of throwing an error. This behavior masked the failure from the client, leading to a confusing user experience.

This change modifies the error handling in `generateAIQuestion` to re-throw the original error if the fallback generation also fails. This ensures that the client is properly notified of the error and can handle it gracefully.

A new test case has been added to `convex/ai.test.ts` to verify this behavior. The test simulates a complete failure of the AI generation and asserts that an error is thrown, confirming the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates errors from generateAIQuestion on complete failure and adds a test verifying retry+fallback error behavior.
> 
> - **Backend**:
>   - **Error propagation**: In `convex/ai.ts`, `generateAIQuestion` now throws the original error when both primary generation and fallback fail (was returning `[]`).
> - **Tests**:
>   - Add `beforeEach` to reset `mockCreate` in `convex/ai.test.ts`.
>   - New test asserts error is thrown on complete failure and that OpenAI is called 4 times (3 retries + 1 fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e3f9541b6860ce7618ab692c0637c0ade352869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->