### PR TITLE
Improve today view theming and always show style/tone settings

### DIFF
--- a/src/app/org/today/page.tsx
+++ b/src/app/org/today/page.tsx
@@ -55,7 +55,7 @@ const SIGNALS = [
 ];
 
 const themeToggleClass =
-  "shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground";
+  "shrink-0 self-start border border-input bg-background hover:bg-accent hover:text-accent-foreground";
 
 interface TodayStateShellProps {
   children: React.ReactNode;

--- a/src/app/org/today/page.tsx
+++ b/src/app/org/today/page.tsx
@@ -201,7 +201,7 @@ export default function CoachDailyViewPage() {
           <h1 className="text-2xl font-bold tracking-tight">Today's Ice-Breaker</h1>
           {coachToday.dayOfWeek && (
             <p className="text-muted-foreground text-sm mt-1">
-              <span className="ml-2">· {coachToday.dayOfWeek}</span>
+              {coachToday.dayOfWeek}
             </p>
           )}
         </div>

--- a/src/app/org/today/page.tsx
+++ b/src/app/org/today/page.tsx
@@ -65,7 +65,7 @@ interface TodayStateShellProps {
 
 function TodayStateShell({ children, className = "relative flex items-center justify-center min-h-[60vh] px-4", themeToggleClassName = themeToggleClass }: TodayStateShellProps) {
   return (
-    <div className={className}>
+    <div className={cn("relative", className)}>
       <div className="absolute top-0 right-4">
         <ThemeToggle className={themeToggleClassName} showLabel={false} />
       </div>

--- a/src/app/org/today/page.tsx
+++ b/src/app/org/today/page.tsx
@@ -19,15 +19,43 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { cn } from "@/lib/utils";
 import { Link } from "react-router-dom";
 
 const SIGNALS = [
-  { key: "landedWell" as const, label: "Landed well", icon: ThumbsUp, color: "text-emerald-400", bg: "bg-emerald-400/10 border-emerald-400/30" },
-  { key: "fellFlat" as const, label: "Fell flat", icon: ThumbsDown, color: "text-red-400", bg: "bg-red-400/10 border-red-400/30" },
-  { key: "wrongVibe" as const, label: "Wrong vibe", icon: Meh, color: "text-amber-400", bg: "bg-amber-400/10 border-amber-400/30" },
-  { key: "timingOff" as const, label: "Timing off", icon: Clock, color: "text-blue-400", bg: "bg-blue-400/10 border-blue-400/30" },
+  {
+    key: "landedWell" as const,
+    label: "Landed well",
+    icon: ThumbsUp,
+    color: "text-emerald-600 dark:text-emerald-400",
+    bg: "bg-emerald-500/10 dark:bg-emerald-400/10 border-emerald-500/30 dark:border-emerald-400/30",
+  },
+  {
+    key: "fellFlat" as const,
+    label: "Fell flat",
+    icon: ThumbsDown,
+    color: "text-red-600 dark:text-red-400",
+    bg: "bg-red-500/10 dark:bg-red-400/10 border-red-500/30 dark:border-red-400/30",
+  },
+  {
+    key: "wrongVibe" as const,
+    label: "Wrong vibe",
+    icon: Meh,
+    color: "text-amber-600 dark:text-amber-400",
+    bg: "bg-amber-500/10 dark:bg-amber-400/10 border-amber-500/30 dark:border-amber-400/30",
+  },
+  {
+    key: "timingOff" as const,
+    label: "Timing off",
+    icon: Clock,
+    color: "text-blue-600 dark:text-blue-400",
+    bg: "bg-blue-500/10 dark:bg-blue-400/10 border-blue-500/30 dark:border-blue-400/30",
+  },
 ];
+
+const themeToggleClass =
+  "shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground";
 
 export default function CoachDailyViewPage() {
   const { activeWorkspace, workspaceHydrated } = useWorkspace();
@@ -104,7 +132,10 @@ export default function CoachDailyViewPage() {
 
   if (!workspaceHydrated) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
+      <div className="relative flex items-center justify-center min-h-[60vh] px-4">
+        <div className="absolute top-0 right-4">
+          <ThemeToggle className={themeToggleClass} showLabel={false} />
+        </div>
         <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
       </div>
     );
@@ -112,7 +143,10 @@ export default function CoachDailyViewPage() {
 
   if (!orgId) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+      <div className="relative flex flex-col items-center justify-center min-h-[60vh] gap-4 px-4">
+        <div className="absolute top-0 right-4">
+          <ThemeToggle className={themeToggleClass} showLabel={false} />
+        </div>
         <CalendarDays className="size-14 opacity-20" />
         <h2 className="text-xl font-semibold">No organization selected</h2>
         <p className="text-muted-foreground text-center max-w-md text-sm">
@@ -127,7 +161,10 @@ export default function CoachDailyViewPage() {
 
   if (coachToday === undefined) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
+      <div className="relative flex items-center justify-center min-h-[60vh] px-4">
+        <div className="absolute top-0 right-4">
+          <ThemeToggle className={themeToggleClass} showLabel={false} />
+        </div>
         <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
       </div>
     );
@@ -137,7 +174,10 @@ export default function CoachDailyViewPage() {
 
   if (!assignment) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
+      <div className="relative flex flex-col items-center justify-center min-h-[60vh] gap-4 px-4 text-center">
+        <div className="absolute top-0 right-4">
+          <ThemeToggle className={themeToggleClass} showLabel={false} />
+        </div>
         <CalendarDays className="size-14 opacity-20" />
         <h2 className="text-xl font-semibold">No question for today</h2>
         <p className="text-muted-foreground max-w-md text-sm">
@@ -150,12 +190,15 @@ export default function CoachDailyViewPage() {
 
   /* ── Today's card ── */
   return (
-    <div className="space-y-6 max-w-2xl mx-auto">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Today's Ice-Breaker</h1>
-        <p className="text-muted-foreground text-sm mt-1">
-          {coachToday.dayOfWeek && <span className="ml-2">· {coachToday.dayOfWeek}</span>}
-        </p>
+    <div className="space-y-6 max-w-2xl mx-auto p-4">
+      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Today's Ice-Breaker</h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            {coachToday.dayOfWeek && <span className="ml-2">· {coachToday.dayOfWeek}</span>}
+          </p>
+        </div>
+        <ThemeToggle className={themeToggleClass} showLabel={false} />
       </div>
 
       {/* Question display */}
@@ -251,12 +294,14 @@ export default function CoachDailyViewPage() {
           </CardContent>
         </Card>
       ) : (
-        <Card className="border-emerald-400/20 bg-emerald-400/5">
+        <Card className="border-emerald-500/20 dark:border-emerald-400/20 bg-emerald-500/5 dark:bg-emerald-400/5">
           <CardContent className="p-6">
             <div className="flex items-center gap-3">
-              <ThumbsUp className="size-5 text-emerald-400" />
+              <ThumbsUp className="size-5 text-emerald-600 dark:text-emerald-400" />
               <div>
-                <p className="font-semibold text-emerald-400">Thanks for your feedback!</p>
+                <p className="font-semibold text-emerald-700 dark:text-emerald-400">
+                  Thanks for your feedback!
+                </p>
                 <p className="text-sm text-muted-foreground mt-0.5">
                   Your input helps refine next week's suggestions.
                 </p>
@@ -277,19 +322,19 @@ export default function CoachDailyViewPage() {
                 <p className="text-xs text-muted-foreground">Responses</p>
               </div>
               <div>
-                <p className="text-2xl font-bold text-emerald-400">
+                <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
                   {feedbackReport.summary.landedWellPct.toFixed(0)}%
                 </p>
                 <p className="text-xs text-muted-foreground">Landed Well</p>
               </div>
               <div>
-                <p className="text-2xl font-bold text-red-400">
+                <p className="text-2xl font-bold text-red-600 dark:text-red-400">
                   {feedbackReport.summary.fellFlatPct.toFixed(0)}%
                 </p>
                 <p className="text-xs text-muted-foreground">Fell Flat</p>
               </div>
               <div>
-                <p className="text-2xl font-bold text-amber-400">
+                <p className="text-2xl font-bold text-amber-600 dark:text-amber-400">
                   {feedbackReport.summary.wrongVibePct.toFixed(0)}%
                 </p>
                 <p className="text-xs text-muted-foreground">Wrong Vibe</p>

--- a/src/app/org/today/page.tsx
+++ b/src/app/org/today/page.tsx
@@ -57,6 +57,23 @@ const SIGNALS = [
 const themeToggleClass =
   "shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground";
 
+interface TodayStateShellProps {
+  children: React.ReactNode;
+  className?: string;
+  themeToggleClassName?: string;
+}
+
+function TodayStateShell({ children, className = "relative flex items-center justify-center min-h-[60vh] px-4", themeToggleClassName = themeToggleClass }: TodayStateShellProps) {
+  return (
+    <div className={className}>
+      <div className="absolute top-0 right-4">
+        <ThemeToggle className={themeToggleClassName} showLabel={false} />
+      </div>
+      {children}
+    </div>
+  );
+}
+
 export default function CoachDailyViewPage() {
   const { activeWorkspace, workspaceHydrated } = useWorkspace();
   const { orgRole, isLoaded: clerkAuthLoaded } = useAuth();
@@ -132,21 +149,15 @@ export default function CoachDailyViewPage() {
 
   if (!workspaceHydrated) {
     return (
-      <div className="relative flex items-center justify-center min-h-[60vh] px-4">
-        <div className="absolute top-0 right-4">
-          <ThemeToggle className={themeToggleClass} showLabel={false} />
-        </div>
+      <TodayStateShell>
         <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
-      </div>
+      </TodayStateShell>
     );
   }
 
   if (!orgId) {
     return (
-      <div className="relative flex flex-col items-center justify-center min-h-[60vh] gap-4 px-4">
-        <div className="absolute top-0 right-4">
-          <ThemeToggle className={themeToggleClass} showLabel={false} />
-        </div>
+      <TodayStateShell className="relative flex flex-col items-center justify-center min-h-[60vh] gap-4 px-4">
         <CalendarDays className="size-14 opacity-20" />
         <h2 className="text-xl font-semibold">No organization selected</h2>
         <p className="text-muted-foreground text-center max-w-md text-sm">
@@ -155,18 +166,15 @@ export default function CoachDailyViewPage() {
         <Button asChild variant="outline">
           <Link to="/settings">Go to Settings</Link>
         </Button>
-      </div>
+      </TodayStateShell>
     );
   }
 
   if (coachToday === undefined) {
     return (
-      <div className="relative flex items-center justify-center min-h-[60vh] px-4">
-        <div className="absolute top-0 right-4">
-          <ThemeToggle className={themeToggleClass} showLabel={false} />
-        </div>
+      <TodayStateShell>
         <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
-      </div>
+      </TodayStateShell>
     );
   }
 
@@ -174,17 +182,14 @@ export default function CoachDailyViewPage() {
 
   if (!assignment) {
     return (
-      <div className="relative flex flex-col items-center justify-center min-h-[60vh] gap-4 px-4 text-center">
-        <div className="absolute top-0 right-4">
-          <ThemeToggle className={themeToggleClass} showLabel={false} />
-        </div>
+      <TodayStateShell className="relative flex flex-col items-center justify-center min-h-[60vh] gap-4 px-4 text-center">
         <CalendarDays className="size-14 opacity-20" />
         <h2 className="text-xl font-semibold">No question for today</h2>
         <p className="text-muted-foreground max-w-md text-sm">
           Your organization hasn't assigned a question for today yet.
           Ask your admin to set up the weekly schedule.
         </p>
-      </div>
+      </TodayStateShell>
     );
   }
 
@@ -194,9 +199,11 @@ export default function CoachDailyViewPage() {
       <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Today's Ice-Breaker</h1>
-          <p className="text-muted-foreground text-sm mt-1">
-            {coachToday.dayOfWeek && <span className="ml-2">· {coachToday.dayOfWeek}</span>}
-          </p>
+          {coachToday.dayOfWeek && (
+            <p className="text-muted-foreground text-sm mt-1">
+              <span className="ml-2">· {coachToday.dayOfWeek}</span>
+            </p>
+          )}
         </div>
         <ThemeToggle className={themeToggleClass} showLabel={false} />
       </div>

--- a/src/app/settings/page.test.tsx
+++ b/src/app/settings/page.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@clerk/clerk-react/experimental", () => ({
   SubscriptionDetailsButton: ({ children }: any) => <>{children}</>,
 }));
 
-vi.mock("@/hooks/useTheme", () => ({
+vi.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({ effectiveTheme: "light" }),
 }));
 
@@ -27,7 +27,7 @@ vi.mock("@/hooks/useWorkspace", () => ({
   useWorkspace: () => ({ activeWorkspace: null }),
 }));
 
-vi.mock("@/hooks/useStorageContext", () => ({
+vi.mock("../../hooks/useStorageContext", () => ({
   useStorageContext: () => mockUseStorageContext(),
 }));
 

--- a/src/app/settings/page.test.tsx
+++ b/src/app/settings/page.test.tsx
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SettingsPage from "./page";
+import { useQuery } from "convex/react";
+
+const mockUseAuth = vi.fn();
+const mockUseStorageContext = vi.fn();
+const mockUseSearchParams = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("@clerk/clerk-react/experimental", () => ({
+  SubscriptionDetailsButton: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useTheme", () => ({
+  useTheme: () => ({ effectiveTheme: "light" }),
+}));
+
+vi.mock("@/hooks/useWorkspace", () => ({
+  useWorkspace: () => ({ activeWorkspace: null }),
+}));
+
+vi.mock("@/hooks/useStorageContext", () => ({
+  useStorageContext: () => mockUseStorageContext(),
+}));
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+vi.mock("@/components/header", () => ({
+  Header: () => <div>Header</div>,
+}));
+
+vi.mock("@/components/collapsible-section/CollapsibleSection", () => ({
+  CollapsibleSection: ({ title, children }: any) => (
+    <section>
+      <h2>{title}</h2>
+      <div>{children}</div>
+    </section>
+  ),
+}));
+
+vi.mock("@/components/ui/dynamic-icon", () => ({
+  default: () => <span aria-hidden="true">icon</span>,
+}));
+
+vi.mock("@/components/item-detail-drawer/item-detail-drawer", () => ({
+  ItemDetailDrawer: () => null,
+}));
+
+vi.mock("@/app/settings/organization/page", () => ({
+  default: () => <div>Organization Settings</div>,
+}));
+
+vi.mock("@/app/settings/organization/WorkspaceSwitcher", () => ({
+  default: () => <div>Workspace Switcher</div>,
+}));
+
+vi.mock("@/app/settings/collections/page", () => ({
+  default: () => <div>Collections Settings</div>,
+}));
+
+vi.mock("@/components/SignInCTA", () => ({
+  SignInCTA: () => <div>Sign In CTA</div>,
+}));
+
+vi.mock("lucide-react", () => ({
+  Link: () => <span aria-hidden="true">link</span>,
+  ExternalLink: () => <span aria-hidden="true">external</span>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../../convex/_generated/api", () => ({
+  api: {
+    core: {
+      styles: { getStyles: "getStyles" },
+      tones: { getTones: "getTones" },
+      users: { getCurrentUser: "getCurrentUser" },
+      billing: { getEffectiveEntitlements: "getEffectiveEntitlements" },
+      questions: { getQuestionsByIds: "getQuestionsByIds" },
+    },
+  },
+}));
+
+describe("SettingsPage", () => {
+  const mockStyles = [
+    { _id: "style-1", id: "style-1", name: "Reflective", icon: "sparkles", color: "#111111" },
+  ];
+  const mockTones = [
+    { _id: "tone-1", id: "tone-1", name: "Warm", icon: "sun", color: "#222222" },
+  ];
+  const mockHiddenQuestionObjects: never[] = [];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockUseAuth.mockReturnValue({ isSignedIn: false });
+    mockUseSearchParams.mockReturnValue([new URLSearchParams()]);
+    mockUseStorageContext.mockReturnValue({
+      hiddenStyles: [],
+      setHiddenStyles: vi.fn(),
+      addHiddenStyle: vi.fn(),
+      removeHiddenStyle: vi.fn(),
+      hiddenTones: [],
+      setHiddenTones: vi.fn(),
+      addHiddenTone: vi.fn(),
+      removeHiddenTone: vi.fn(),
+      hiddenQuestions: [],
+      setHiddenQuestions: vi.fn(),
+      removeHiddenQuestion: vi.fn(),
+      clearHiddenQuestions: vi.fn(),
+      storageLimitBehavior: "block",
+      setStorageLimitBehavior: vi.fn(),
+    });
+
+    (useQuery as any).mockImplementation((queryFn: string) => {
+      if (queryFn === "getStyles") return mockStyles;
+      if (queryFn === "getTones") return mockTones;
+      if (queryFn === "getQuestionsByIds") return mockHiddenQuestionObjects;
+      if (queryFn === "getCurrentUser") return null;
+      if (queryFn === "getEffectiveEntitlements") return null;
+      return undefined;
+    });
+  });
+
+  it("shows style and tone controls for users outside a team workspace", () => {
+    render(<SettingsPage />);
+
+    expect(screen.getByText("Manage Styles")).toBeDefined();
+    expect(screen.getByText("Manage Tones")).toBeDefined();
+    expect(screen.getByText("Reflective")).toBeDefined();
+    expect(screen.getByText("Warm")).toBeDefined();
+  });
+});

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -332,9 +332,22 @@ const SettingsPage = () => {
             visibleCount={visibleStyleCount}
             hiddenCount={hiddenStyleCount}
           >
-            {typeof allStyles === 'undefined' ? (
+            {!isSignedIn ? (
+              <div className="p-4">
+                <p className="dark:text-white/70 text-black/70 mb-4">Sign in to manage your style preferences.</p>
+                <SignInCTA
+                  bgGradient={((effectiveTheme === 'dark' ? gradientDark : gradientLight) as unknown) as [string, string]}
+                  title="Sign In to Customize Styles"
+                  featureHighlight={{
+                    pre: "Personalize your",
+                    highlight: "style preferences",
+                    post: "with an account."
+                  }}
+                />
+              </div>
+            ) : typeof allStyles === 'undefined' ? (
               <div className="flex items-center justify-center p-8">
-                <div className="animate-spin size-6 border-2 border-white/20 dark:border-white/20 border-t-white dark:border-t-white rounded-full" />
+                <div className="animate-spin size-6 border-2 border-gray-200 dark:border-white/20 border-t-gray-500 dark:border-t-white rounded-full" />
               </div>
             ) : allStyles.length === 0 ? (
               <p className="dark:text-white/70 text-black/70">No styles available to manage.</p>
@@ -392,9 +405,22 @@ const SettingsPage = () => {
             visibleCount={visibleToneCount}
             hiddenCount={hiddenToneCount}
           >
-            {typeof allTones === 'undefined' ? (
+            {!isSignedIn ? (
+              <div className="p-4">
+                <p className="dark:text-white/70 text-black/70 mb-4">Sign in to manage your tone preferences.</p>
+                <SignInCTA
+                  bgGradient={((effectiveTheme === 'dark' ? gradientDark : gradientLight) as unknown) as [string, string]}
+                  title="Sign In to Customize Tones"
+                  featureHighlight={{
+                    pre: "Personalize your",
+                    highlight: "tone preferences",
+                    post: "with an account."
+                  }}
+                />
+              </div>
+            ) : typeof allTones === 'undefined' ? (
               <div className="flex items-center justify-center p-8">
-                <div className="animate-spin size-6 border-2 border-white/20 dark:border-white/20 border-t-white dark:border-t-white rounded-full" />
+                <div className="animate-spin size-6 border-2 border-gray-200 dark:border-white/20 border-t-gray-500 dark:border-t-white rounded-full" />
               </div>
             ) : allTones.length === 0 ? (
               <p className="dark:text-white/70 text-black/70">No tones available to manage.</p>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -325,122 +325,118 @@ const SettingsPage = () => {
             </CollapsibleSection>
           )}
 
-          {isSignedIn && (
-            <CollapsibleSection
-              title="Manage Styles"
-              isOpen={!!openSections['manage-styles']}
-              onOpenChange={() => toggleSection('manage-styles')}
-              visibleCount={visibleStyleCount}
-              hiddenCount={hiddenStyleCount}
-            >
-              {allStyles && allStyles.length > 0 ? (
-                <>
-                  <div className="flex space-x-2 mb-4">
-                    <button
-                      onClick={() => setHiddenStyles([])}
-                      className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
-                    >
-                      Include All
-                    </button>
-                    <button
-                      onClick={() => setHiddenStyles(allStyles.map(s => s._id))}
-                      className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
-                    >
-                      Hide All
-                    </button>
-                  </div>
-                  <ul className="space-y-2">
-                    {allStyles.map(style => {
-                      const isIncluded = !hiddenStyles?.includes(style._id);
-                      return (
-                        <li key={style._id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
-                          <div className="flex items-center">
-                            <DynamicIcon name={style.icon} color={style.color} size={24} className="mr-2" />
-                            <span className="dark:text-white text-black">{style.name}</span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <button onClick={() => handleShowInfo(style, "Style")} className="p-1">
-                              <DynamicIcon name="info" size={18} />
-                            </button>
-                            <button
-                              onClick={() => handleToggleStyle(style._id)}
-                              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isIncluded ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
-                              aria-pressed={isIncluded}
-                              aria-label={`Toggle style ${style.name}`}
-                            >
-                              <span
-                                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isIncluded ? 'translate-x-6' : 'translate-x-1'}`}
-                              />
-                            </button>
-                          </div>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </>
-              ) : (
-                <p className="dark:text-white/70 text-black/70">No styles available to manage.</p>
-              )}
-            </CollapsibleSection>
-          )}
-          {isSignedIn && (
-            <CollapsibleSection
-              title="Manage Tones"
-              isOpen={!!openSections['manage-tones']}
-              onOpenChange={() => toggleSection('manage-tones')}
-              visibleCount={visibleToneCount}
-              hiddenCount={hiddenToneCount}
-            >
-              {allTones && allTones.length > 0 ? (
-                <>
-                  <div className="flex space-x-2 mb-4">
-                    <button
-                      onClick={() => setHiddenTones([])}
-                      className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
-                    >
-                      Include All
-                    </button>
-                    <button
-                      onClick={() => setHiddenTones(allTones.map(t => t._id))}
-                      className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
-                    >
-                      Hide All
-                    </button>
-                  </div>
-                  <ul className="space-y-2">
-                    {allTones.map(tone => {
-                      const isIncluded = !hiddenTones?.includes(tone._id);
-                      return (
-                        <li key={tone._id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
-                          <div className="flex items-center">
-                            <DynamicIcon name={tone.icon} color={tone.color} size={24} className="mr-2" />
-                            <span className="dark:text-white text-black">{tone.name}</span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <button onClick={() => handleShowInfo(tone, "Tone")} className="p-1">
-                              <DynamicIcon name="info" size={18} />
-                            </button>
-                            <button
-                              onClick={() => handleToggleTone(tone._id)}
-                              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isIncluded ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
-                              aria-pressed={isIncluded}
-                              aria-label={`Toggle tone ${tone.name}`}
-                            >
-                              <span
-                                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isIncluded ? 'translate-x-6' : 'translate-x-1'}`}
-                              />
-                            </button>
-                          </div>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </>
-              ) : (
-                <p className="dark:text-white/70 text-black/70">No tones available to manage.</p>
-              )}
-            </CollapsibleSection>
-          )}
+          <CollapsibleSection
+            title="Manage Styles"
+            isOpen={!!openSections['manage-styles']}
+            onOpenChange={() => toggleSection('manage-styles')}
+            visibleCount={visibleStyleCount}
+            hiddenCount={hiddenStyleCount}
+          >
+            {allStyles && allStyles.length > 0 ? (
+              <>
+                <div className="flex space-x-2 mb-4">
+                  <button
+                    onClick={() => setHiddenStyles([])}
+                    className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
+                  >
+                    Include All
+                  </button>
+                  <button
+                    onClick={() => setHiddenStyles(allStyles.map(s => s._id))}
+                    className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
+                  >
+                    Hide All
+                  </button>
+                </div>
+                <ul className="space-y-2">
+                  {allStyles.map(style => {
+                    const isIncluded = !hiddenStyles?.includes(style._id);
+                    return (
+                      <li key={style._id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
+                        <div className="flex items-center">
+                          <DynamicIcon name={style.icon} color={style.color} size={24} className="mr-2" />
+                          <span className="dark:text-white text-black">{style.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <button onClick={() => handleShowInfo(style, "Style")} className="p-1">
+                            <DynamicIcon name="info" size={18} />
+                          </button>
+                          <button
+                            onClick={() => handleToggleStyle(style._id)}
+                            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isIncluded ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
+                            aria-pressed={isIncluded}
+                            aria-label={`Toggle style ${style.name}`}
+                          >
+                            <span
+                              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isIncluded ? 'translate-x-6' : 'translate-x-1'}`}
+                            />
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            ) : (
+              <p className="dark:text-white/70 text-black/70">No styles available to manage.</p>
+            )}
+          </CollapsibleSection>
+          <CollapsibleSection
+            title="Manage Tones"
+            isOpen={!!openSections['manage-tones']}
+            onOpenChange={() => toggleSection('manage-tones')}
+            visibleCount={visibleToneCount}
+            hiddenCount={hiddenToneCount}
+          >
+            {allTones && allTones.length > 0 ? (
+              <>
+                <div className="flex space-x-2 mb-4">
+                  <button
+                    onClick={() => setHiddenTones([])}
+                    className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
+                  >
+                    Include All
+                  </button>
+                  <button
+                    onClick={() => setHiddenTones(allTones.map(t => t._id))}
+                    className="px-3 py-1 text-sm font-semibold bg-white/20 dark:bg-black/20 dark:text-white text-black rounded-md hover:bg-white/30 transition-colors"
+                  >
+                    Hide All
+                  </button>
+                </div>
+                <ul className="space-y-2">
+                  {allTones.map(tone => {
+                    const isIncluded = !hiddenTones?.includes(tone._id);
+                    return (
+                      <li key={tone._id} className="flex items-center justify-between p-3 bg-white/10 backdrop-blur-sm rounded-lg">
+                        <div className="flex items-center">
+                          <DynamicIcon name={tone.icon} color={tone.color} size={24} className="mr-2" />
+                          <span className="dark:text-white text-black">{tone.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <button onClick={() => handleShowInfo(tone, "Tone")} className="p-1">
+                            <DynamicIcon name="info" size={18} />
+                          </button>
+                          <button
+                            onClick={() => handleToggleTone(tone._id)}
+                            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isIncluded ? 'bg-green-500' : 'bg-white/20 dark:bg-black/20'}`}
+                            aria-pressed={isIncluded}
+                            aria-label={`Toggle tone ${tone.name}`}
+                          >
+                            <span
+                              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isIncluded ? 'translate-x-6' : 'translate-x-1'}`}
+                            />
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            ) : (
+              <p className="dark:text-white/70 text-black/70">No tones available to manage.</p>
+            )}
+          </CollapsibleSection>
 
           {!isSignedIn && hiddenQuestions.length >= MAX_ANON_BLOCKED && (
             <div className="mb-6">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -30,11 +30,11 @@ const SettingsPage = () => {
 
   const allStyles = useQuery(
     api.core.styles.getStyles,
-    { organizationId: activeWorkspace ?? undefined }
+    isSignedIn ? { organizationId: activeWorkspace ?? undefined } : "skip"
   );
   const allTones = useQuery(
     api.core.tones.getTones,
-    { organizationId: activeWorkspace ?? undefined }
+    isSignedIn ? { organizationId: activeWorkspace ?? undefined } : "skip"
   );
   const currentUser = useQuery(api.core.users.getCurrentUser, {
     organizationId: activeWorkspace ?? undefined,
@@ -167,8 +167,9 @@ const SettingsPage = () => {
   const visibleToneCount = allTones?.filter(t => !hiddenTones?.includes(t._id)).length;
   const hiddenToneCount = allTones?.filter(t => hiddenTones?.includes(t._id)).length;
 
-  const gradientLight = ["#667EEA", "#A064DE"];
-  const gradientDark = ["#3B2554", "#262D54"];
+  const gradientLight: [string, string] = ["#667EEA", "#A064DE"];
+  const gradientDark: [string, string] = ["#3B2554", "#262D54"];
+  const bgGradient = effectiveTheme === 'dark' ? gradientDark : gradientLight;
   return (
     <div
       className="min-h-screen transition-colors overflow-hidden"
@@ -336,7 +337,7 @@ const SettingsPage = () => {
               <div className="p-4">
                 <p className="dark:text-white/70 text-black/70 mb-4">Sign in to manage your style preferences.</p>
                 <SignInCTA
-                  bgGradient={((effectiveTheme === 'dark' ? gradientDark : gradientLight) as unknown) as [string, string]}
+                  bgGradient={bgGradient}
                   title="Sign In to Customize Styles"
                   featureHighlight={{
                     pre: "Personalize your",
@@ -409,7 +410,7 @@ const SettingsPage = () => {
               <div className="p-4">
                 <p className="dark:text-white/70 text-black/70 mb-4">Sign in to manage your tone preferences.</p>
                 <SignInCTA
-                  bgGradient={((effectiveTheme === 'dark' ? gradientDark : gradientLight) as unknown) as [string, string]}
+                  bgGradient={bgGradient}
                   title="Sign In to Customize Tones"
                   featureHighlight={{
                     pre: "Personalize your",
@@ -475,7 +476,7 @@ const SettingsPage = () => {
           {!isSignedIn && hiddenQuestions.length >= MAX_ANON_BLOCKED && (
             <div className="mb-6">
               <SignInCTA
-                bgGradient={((effectiveTheme === 'dark' ? gradientDark : gradientLight) as unknown) as [string, string]}
+                bgGradient={bgGradient}
                 title="Hidden Question Limit Reached"
                 featureHighlight={{
                   pre: "Sign in to hide",

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -334,7 +334,7 @@ const SettingsPage = () => {
           >
             {typeof allStyles === 'undefined' ? (
               <div className="flex items-center justify-center p-8">
-                <div className="animate-spin size-6 border-2 border-white/20 dark:border-black/20 border-t-white dark:border-t-black rounded-full" />
+                <div className="animate-spin size-6 border-2 border-white/20 dark:border-white/20 border-t-white dark:border-t-white rounded-full" />
               </div>
             ) : allStyles.length === 0 ? (
               <p className="dark:text-white/70 text-black/70">No styles available to manage.</p>
@@ -394,7 +394,7 @@ const SettingsPage = () => {
           >
             {typeof allTones === 'undefined' ? (
               <div className="flex items-center justify-center p-8">
-                <div className="animate-spin size-6 border-2 border-white/20 dark:border-black/20 border-t-white dark:border-t-black rounded-full" />
+                <div className="animate-spin size-6 border-2 border-white/20 dark:border-white/20 border-t-white dark:border-t-white rounded-full" />
               </div>
             ) : allTones.length === 0 ? (
               <p className="dark:text-white/70 text-black/70">No tones available to manage.</p>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -332,7 +332,13 @@ const SettingsPage = () => {
             visibleCount={visibleStyleCount}
             hiddenCount={hiddenStyleCount}
           >
-            {allStyles && allStyles.length > 0 ? (
+            {typeof allStyles === 'undefined' ? (
+              <div className="flex items-center justify-center p-8">
+                <div className="animate-spin size-6 border-2 border-white/20 dark:border-black/20 border-t-white dark:border-t-black rounded-full" />
+              </div>
+            ) : allStyles.length === 0 ? (
+              <p className="dark:text-white/70 text-black/70">No styles available to manage.</p>
+            ) : (
               <>
                 <div className="flex space-x-2 mb-4">
                   <button
@@ -358,7 +364,7 @@ const SettingsPage = () => {
                           <span className="dark:text-white text-black">{style.name}</span>
                         </div>
                         <div className="flex items-center gap-2">
-                          <button onClick={() => handleShowInfo(style, "Style")} className="p-1">
+                          <button onClick={() => handleShowInfo(style, "Style")} className="p-1" aria-label={`Show info about ${style.name}`}>
                             <DynamicIcon name="info" size={18} />
                           </button>
                           <button
@@ -377,8 +383,6 @@ const SettingsPage = () => {
                   })}
                 </ul>
               </>
-            ) : (
-              <p className="dark:text-white/70 text-black/70">No styles available to manage.</p>
             )}
           </CollapsibleSection>
           <CollapsibleSection
@@ -388,7 +392,13 @@ const SettingsPage = () => {
             visibleCount={visibleToneCount}
             hiddenCount={hiddenToneCount}
           >
-            {allTones && allTones.length > 0 ? (
+            {typeof allTones === 'undefined' ? (
+              <div className="flex items-center justify-center p-8">
+                <div className="animate-spin size-6 border-2 border-white/20 dark:border-black/20 border-t-white dark:border-t-black rounded-full" />
+              </div>
+            ) : allTones.length === 0 ? (
+              <p className="dark:text-white/70 text-black/70">No tones available to manage.</p>
+            ) : (
               <>
                 <div className="flex space-x-2 mb-4">
                   <button
@@ -414,7 +424,7 @@ const SettingsPage = () => {
                           <span className="dark:text-white text-black">{tone.name}</span>
                         </div>
                         <div className="flex items-center gap-2">
-                          <button onClick={() => handleShowInfo(tone, "Tone")} className="p-1">
+                          <button onClick={() => handleShowInfo(tone, "Tone")} className="p-1" aria-label={`Show info about ${tone.name}`}>
                             <DynamicIcon name="info" size={18} />
                           </button>
                           <button
@@ -433,8 +443,6 @@ const SettingsPage = () => {
                   })}
                 </ul>
               </>
-            ) : (
-              <p className="dark:text-white/70 text-black/70">No tones available to manage.</p>
             )}
           </CollapsibleSection>
 


### PR DESCRIPTION
## Summary
- Added theme toggle and layout polish to the Coach Daily View page, including improved dark-mode-aware signal and feedback styling.
- Kept the theme toggle available during loading, empty, and no-assignment states so users can switch appearance everywhere on the page.
- Always render the Style and Tone management sections in Settings, rather than hiding them behind sign-in state.
- Added a settings page test covering visibility of style and tone controls for users outside a team workspace.

## Testing
- Added `src/app/settings/page.test.tsx` to verify that Manage Styles and Manage Tones render with mock style/tone data.
- Not run: full test suite.
- Not run: manual UI verification in the browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme toggle consistently accessible on the Today page (top-right) across all UI states; also present inline in the header.
  * Style and Tone management controls always visible; show sign-in prompt when not signed in.

* **Improvements**
  * Brighter, more consistent colors with dark-mode variants for signals, feedback cards, and weekly summaries.
  * Header and card layout improved for responsiveness and spacing; loading/empty states now centered and wrapped with preserved toggle placement.
  * Info buttons include accessible labels.

* **Tests**
  * Added test coverage for the settings page UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->