### PR TITLE
Add recoverable retry mechanism for `/get-question-for-user`

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -42,22 +42,31 @@ export const getQuestionForUserHttp = httpAction(async (ctx, request) => {
 
 	let attempts = 0;
 	const maxAttempts = 3;
+	let hadRetry = false;
 
 	while (attempts < maxAttempts) {
 		try {
 			const result = await ctx.runAction(internal.internal.newsletter.getQuestionForUser, { email });
+
+			if (hadRetry) {
+				console.log(`Successfully retrieved question for ${email} after ${attempts} attempt(s)`);
+			}
+
 			return new Response(JSON.stringify(result), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
 			});
 		} catch (error: any) {
 			attempts++;
+			hadRetry = true;
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			console.error(`Attempt ${attempts} failed:`, error);
 
 			const isRecoverable =
-				errorMessage.includes("There are no available workers to process the request") ||
-				errorMessage.includes("Your request couldn't be completed. Try again later.");
+				(error.data && error.data.kind === "RateLimited") ||
+				(error.data && error.data.retryAfter) ||
+				error.statusCode === 503 ||
+				errorMessage.includes("worker");
 
 			if (isRecoverable && attempts < maxAttempts) {
 				const delay = Math.pow(2, attempts) * 1000;
@@ -68,8 +77,6 @@ export const getQuestionForUserHttp = httpAction(async (ctx, request) => {
 			return new Response("Failed to get question", { status: 500 });
 		}
 	}
-
-	return new Response("Failed to get question", { status: 500 });
 });
 
 http.route({

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -49,7 +49,7 @@ export const getQuestionForUserHttp = httpAction(async (ctx, request) => {
 			const result = await ctx.runAction(internal.internal.newsletter.getQuestionForUser, { email });
 
 			if (hadRetry) {
-				console.log(`Successfully retrieved question for ${email} after ${attempts} attempt(s)`);
+				console.log(`Successfully retrieved question after ${attempts + 1} attempt(s)`);
 			}
 
 			return new Response(JSON.stringify(result), {
@@ -62,11 +62,18 @@ export const getQuestionForUserHttp = httpAction(async (ctx, request) => {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			console.error(`Attempt ${attempts} failed:`, error);
 
-			const isRecoverable =
-				(error.data && error.data.kind === "RateLimited") ||
-				(error.data && error.data.retryAfter) ||
-				error.statusCode === 503 ||
-				errorMessage.includes("worker");
+			// Normalize error handling to support multiple error shapes:
+			// 1. Convex error: error.data.kind, error.data.retryAfter, error.statusCode
+			// 2. APIError (OpenAI): error.status, error.headers['retry-after']
+			const status = error.status ?? error.statusCode;
+			const isRateLimited = error.data?.kind === "RateLimited";
+			const hasRetryAfter =
+				error.data?.retryAfter ||
+				(error.headers instanceof Headers ? error.headers.get("retry-after") : error.headers?.["retry-after"]);
+			const is5xxError = status !== undefined && status >= 500;
+			const isWorkerError = errorMessage.includes("worker");
+
+			const isRecoverable = isRateLimited || hasRetryAfter || is5xxError || isWorkerError;
 
 			if (isRecoverable && attempts < maxAttempts) {
 				const delay = Math.pow(2, attempts) * 1000;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -40,16 +40,36 @@ export const getQuestionForUserHttp = httpAction(async (ctx, request) => {
 		return new Response("Missing email", { status: 400 });
 	}
 
-	try {
-		const result = await ctx.runAction(internal.internal.newsletter.getQuestionForUser, { email });
-		return new Response(JSON.stringify(result), {
-			status: 200,
-			headers: { "Content-Type": "application/json" },
-		});
-	} catch (error) {
-		console.error(error);
-		return new Response("Failed to get question", { status: 500 });
+	let attempts = 0;
+	const maxAttempts = 3;
+
+	while (attempts < maxAttempts) {
+		try {
+			const result = await ctx.runAction(internal.internal.newsletter.getQuestionForUser, { email });
+			return new Response(JSON.stringify(result), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		} catch (error: any) {
+			attempts++;
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			console.error(`Attempt ${attempts} failed:`, error);
+
+			const isRecoverable =
+				errorMessage.includes("There are no available workers to process the request") ||
+				errorMessage.includes("Your request couldn't be completed. Try again later.");
+
+			if (isRecoverable && attempts < maxAttempts) {
+				const delay = Math.pow(2, attempts) * 1000;
+				await new Promise(resolve => setTimeout(resolve, delay));
+				continue;
+			}
+
+			return new Response("Failed to get question", { status: 500 });
+		}
 	}
+
+	return new Response("Failed to get question", { status: 500 });
 });
 
 http.route({

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -21,7 +21,7 @@ http.route({
 	handler: usersWebhook,
 });
 
-export const getQuestionForUserHttp = httpAction(async (ctx, request) => {
+export const getQuestionForUserHttp = httpAction(async (ctx, request): Promise<Response> => {
 	const authHeader = request.headers.get("Authorization");
 	const expectedToken = process.env.N8N_WEBHOOK_SECRET;
 
@@ -42,38 +42,22 @@ export const getQuestionForUserHttp = httpAction(async (ctx, request) => {
 
 	let attempts = 0;
 	const maxAttempts = 3;
-	let hadRetry = false;
 
 	while (attempts < maxAttempts) {
 		try {
 			const result = await ctx.runAction(internal.internal.newsletter.getQuestionForUser, { email });
-
-			if (hadRetry) {
-				console.log(`Successfully retrieved question after ${attempts + 1} attempt(s)`);
-			}
-
 			return new Response(JSON.stringify(result), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
 			});
 		} catch (error: any) {
 			attempts++;
-			hadRetry = true;
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			console.error(`Attempt ${attempts} failed:`, error);
 
-			// Normalize error handling to support multiple error shapes:
-			// 1. Convex error: error.data.kind, error.data.retryAfter, error.statusCode
-			// 2. APIError (OpenAI): error.status, error.headers['retry-after']
-			const status = error.status ?? error.statusCode;
-			const isRateLimited = error.data?.kind === "RateLimited";
-			const hasRetryAfter =
-				error.data?.retryAfter ||
-				(error.headers instanceof Headers ? error.headers.get("retry-after") : error.headers?.["retry-after"]);
-			const is5xxError = status !== undefined && status >= 500;
-			const isWorkerError = errorMessage.includes("worker");
-
-			const isRecoverable = isRateLimited || hasRetryAfter || is5xxError || isWorkerError;
+			const isRecoverable =
+				errorMessage.includes("There are no available workers to process the request") ||
+				errorMessage.includes("Your request couldn't be completed. Try again later.");
 
 			if (isRecoverable && attempts < maxAttempts) {
 				const delay = Math.pow(2, attempts) * 1000;
@@ -84,6 +68,8 @@ export const getQuestionForUserHttp = httpAction(async (ctx, request) => {
 			return new Response("Failed to get question", { status: 500 });
 		}
 	}
+
+	return new Response("Failed to get question", { status: 500 });
 });
 
 http.route({

--- a/package-lock.json
+++ b/package-lock.json
@@ -4428,6 +4428,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4441,6 +4442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4454,6 +4456,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4467,6 +4470,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4480,6 +4484,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4493,6 +4498,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4506,6 +4512,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4519,6 +4526,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4532,6 +4540,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4545,6 +4554,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4558,6 +4568,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4571,6 +4582,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4584,6 +4596,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4597,6 +4610,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4610,6 +4624,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4623,6 +4638,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4636,6 +4652,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4649,6 +4666,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4662,6 +4680,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4675,6 +4694,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4688,6 +4708,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4701,6 +4722,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4714,6 +4736,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4727,6 +4750,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4740,6 +4764,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4428,7 +4428,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4442,7 +4441,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4456,7 +4454,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4470,7 +4467,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4484,7 +4480,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4498,7 +4493,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4512,7 +4506,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4526,7 +4519,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4540,7 +4532,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4554,7 +4545,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4568,7 +4558,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4582,7 +4571,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4596,7 +4584,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4610,7 +4597,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4624,7 +4610,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4638,7 +4623,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4652,7 +4636,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4666,7 +4649,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4680,7 +4662,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4694,7 +4675,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4708,7 +4688,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4722,7 +4701,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4736,7 +4714,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4750,7 +4727,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4764,7 +4740,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
Added an exponential backoff mechanism in `/get-question-for-user` to automatically retry up to 3 times on recoverable Convex errors.

---
*PR created automatically by Jules for task [2147795096418552259](https://jules.google.com/task/2147795096418552259) started by @tonyisup*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of question retrieval with automatic retry (up to 3 attempts) and exponential backoff for transient failures.
  * Enhanced error handling and logging so recoverable errors are retried and failures return clearer, consistent error responses.
  * Successful requests now return JSON responses; persistent failures return a clear 500 error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->